### PR TITLE
Seed the 51CTO question bank in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/src/prisma ./src/prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+# Bake the question-bank seed into the image. Only the converted JSON is
+# needed at runtime; the raw 51CTO exam scrapes (data/51cto-exams/) and the
+# AI classification map (data/51cto-classifications.json) are build-time
+# artefacts and stay out of the image.
+COPY --from=builder /app/data/51cto-seed.json ./data/51cto-seed.json
 RUN chown -R nextjs:nodejs /app
 
 USER nextjs
@@ -37,4 +42,8 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["sh", "-c", "./node_modules/.bin/prisma migrate deploy --schema src/prisma/schema.prisma && node server.js"]
+# On first boot: apply migrations, then run the seeder once and drop a marker
+# in the data volume so subsequent restarts skip the (~30s) seed step. To
+# force a re-seed (e.g. after pulling a new question-bank version), delete
+# /data/.seeded inside the volume.
+CMD ["sh", "-c", "./node_modules/.bin/prisma migrate deploy --schema src/prisma/schema.prisma && { [ -f /data/.seeded ] || ./node_modules/.bin/tsx src/prisma/seed.ts && touch /data/.seeded; } && node server.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "tsx": "^4.21.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
@@ -53,7 +54,6 @@
         "prettier": "^3.8.3",
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
-        "tsx": "^4.21.0",
         "typescript": "^5.5.3"
       },
       "engines": {
@@ -525,7 +525,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -542,7 +541,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -559,7 +557,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -576,7 +573,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -593,7 +589,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -610,7 +605,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -627,7 +621,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -644,7 +637,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -661,7 +653,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -678,7 +669,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -695,7 +685,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -712,7 +701,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,7 +717,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -746,7 +733,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,7 +749,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -780,7 +765,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,7 +781,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -814,7 +797,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -831,7 +813,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -848,7 +829,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -865,7 +845,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -882,7 +861,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -899,7 +877,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -916,7 +893,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -933,7 +909,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -950,7 +925,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5644,7 +5618,6 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6444,7 +6417,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6627,7 +6599,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -10335,7 +10306,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -11377,7 +11347,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
@@ -108,7 +109,6 @@
     "prettier": "^3.8.3",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
-    "tsx": "^4.21.0",
     "typescript": "^5.5.3"
   }
 }


### PR DESCRIPTION
## Summary

Self-deploys via \`docker-compose\` were starting with an empty database. Three issues stacked on top of each other:

1. The Dockerfile only ran \`prisma migrate deploy\`, never \`prisma db seed\`.
2. \`data/51cto-seed.json\` wasn't copied into the runner stage, so even invoking the seeder would have failed.
3. \`tsx\` (which \`prisma db seed\` calls per \`package.json\` config) was a devDependency and \`npm ci --omit=dev\` stripped it from the prod image.

## Fix

- Moved \`tsx\` to \`dependencies\` (~5 MB image bloat).
- COPY \`data/51cto-seed.json\` into the runner stage. Raw scrapes (\`data/51cto-exams/\`) and the AI classification map (\`data/51cto-classifications.json\`) stay out of the image — they're build-time artefacts only.
- CMD now runs the seeder once after migrate deploy and drops \`/data/.seeded\` so subsequent restarts skip the ~30 s seed. Delete that marker to force a re-seed after a question-bank refresh.

## Test plan

- [x] \`npm run typecheck\` passes
- [ ] Rebuild the image, start the container with an empty volume → \`Exams: 41\` after first boot
- [ ] Restart the same container → seed step is skipped, startup is fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)