### PR TITLE
feat: startup log, verify:portable script, and portable zip docs

### DIFF
--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -65,9 +65,71 @@ In production desktop mode, Tauri:
 5. Polls `/api/ai/status` until the Next.js server is ready.
 6. Navigates the WebView to `http://127.0.0.1:<port>`.
 
+## Portable Zip (Windows)
+
+The Windows portable zip is assembled by the release workflow from the Tauri build output. It is not a native Tauri installer target and has additional requirements compared to the MSI/NSIS installers.
+
+### Required build flags
+
+The portable zip must be built with `BUNDLE_NODE=1` so it ships its own Node.js runtime:
+
+```bash
+BUNDLE_NODE=1 npm run tauri:prepare
+npm run tauri:build
+```
+
+Without `BUNDLE_NODE=1` the zip depends on `node` from the user's `PATH`, which may be absent, the wrong version, or blocked by system policy.
+
+### Verifying the portable bundle
+
+After `tauri:prepare`, run:
+
+```bash
+npm run verify:portable
+```
+
+This checks that all required artifacts are present (`runtime/node.exe`, `start.js`, `server.js`, Prisma engine, migrations, `.next/static`, `public`) and that the bundled Node.js is executable. The release workflow should fail if this check fails.
+
+### Portable zip layout
+
+```
+OSE-Portable/
+  OSE.exe
+  portable.ini
+  README.txt
+  resources/
+    binaries/
+      standalone/
+        runtime/
+          node.exe        ← bundled Node.js (BUNDLE_NODE=1 required)
+        start.js
+        server.js
+        .next/static/
+        public/
+        src/prisma/
+        node_modules/
+```
+
+### Known limitations of the portable zip
+
+- **App data is not portable.** OSE still writes to `%AppData%\com.ose.softwareexam` and the WebView data cache. Deleting the zip does not remove user data. Multiple extracted versions share the same data directory.
+- **WebView2 is not bundled.** The app requires WebView2 Runtime (pre-installed on Windows 11 and updated Windows 10). On machines without it the window will fail to open. Document this in the release notes and consider linking to the WebView2 Evergreen installer.
+- **No updater integration.** There is no automatic update path for the portable zip.
+- **Path sensitivity.** Test extraction paths with spaces, non-ASCII characters, and paths longer than 260 characters (long path support must be enabled on older Windows).
+
 ## Troubleshooting
 
-- **Server startup timeout**: verify Node.js is installed and available in `PATH`, or rebuild with `BUNDLE_NODE=1`.
+- **Server startup timeout**: verify Node.js is installed and available in `PATH`, or rebuild with `BUNDLE_NODE=1`. Check the startup log (see below).
 - **Prisma errors**: run `npm run tauri:prepare` again and confirm migrations were copied.
 - **Port issues**: OSE picks an unused port automatically.
 - **Windows localhost issues**: the desktop app uses `127.0.0.1` to avoid IPv4/IPv6 mismatch.
+
+### Startup log
+
+On every launch the desktop app writes a `startup.log` file to the app data directory:
+
+- **Windows**: `%AppData%\com.ose.softwareexam\startup.log`
+- **macOS**: `~/Library/Application Support/com.ose.softwareexam/startup.log`
+- **Linux**: `~/.local/share/com.ose.softwareexam/startup.log`
+
+The log records the resolved standalone directory, Node.js binary path (bundled or system), selected port, database path, all sidecar stdout/stderr lines, and the final ready or timeout result. Share this file when reporting startup issues.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "tauri:android:build:apk": "node scripts/build-android-apk.js",
     "tauri:prepare": "node scripts/prepare-sidecar.js",
     "tauri:icons": "tauri icon src-tauri/icons/app-icon.png",
+    "verify:portable": "node scripts/verify-portable.js",
     "screenshots": "node scripts/capture-screenshots.mjs",
     "prepare": "husky && npx prisma generate"
   },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,9 @@ use std::{
     net::TcpStream,
     path::PathBuf,
     process::{Child, Command, Stdio},
-    sync::Mutex,
+    sync::{Arc, Mutex},
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 #[cfg(windows)]
@@ -104,6 +104,14 @@ fn start_next_server(app: &AppHandle) -> Result<u16, String> {
     let data_dir = resolve_data_dir(app)?;
     fs::create_dir_all(&data_dir).map_err(|error| format!("创建数据目录失败：{error}"))?;
 
+    let log_path = data_dir.join("startup.log");
+    let log: Option<Arc<Mutex<fs::File>>> = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .ok()
+        .map(|f| Arc::new(Mutex::new(f)));
+
     let standalone_dir = resolve_standalone_dir(app)?;
     let start_script = standalone_dir.join("start.js");
     if !start_script.exists() {
@@ -114,10 +122,20 @@ fn start_next_server(app: &AppHandle) -> Result<u16, String> {
     }
 
     let port = pick_port()?;
-    let database_url = format!("file:{}", data_dir.join("ose.db").to_string_lossy());
-
+    let database_path = data_dir.join("ose.db");
+    let database_url = format!("file:{}", database_path.to_string_lossy());
     let node_binary = resolve_node_binary(&standalone_dir);
     let using_bundled = node_binary != PathBuf::from("node");
+
+    write_startup_header(
+        log.as_ref(),
+        &standalone_dir,
+        &node_binary,
+        using_bundled,
+        port,
+        &database_path,
+        &log_path,
+    );
 
     let mut cmd = Command::new(&node_binary);
     cmd.arg(&start_script)
@@ -138,18 +156,20 @@ fn start_next_server(app: &AppHandle) -> Result<u16, String> {
     cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
 
     let mut child = cmd.spawn().map_err(|error| {
-        if using_bundled {
+        let msg = if using_bundled {
             format!(
                 "启动打包的 Node.js 失败：{error}。可执行文件位置：{}",
                 node_binary.display()
             )
         } else {
             format!("启动 Node.js 失败：{error}。请安装 Node.js 20+ 并加入 PATH，或使用 BUNDLE_NODE=1 重新打包。")
-        }
+        };
+        log_line(log.as_ref(), &format!("[startup] spawn error: {msg}"));
+        msg
     })?;
 
-    pipe_process_output(child.stdout.take(), "next:stdout");
-    pipe_process_output(child.stderr.take(), "next:stderr");
+    pipe_process_output(child.stdout.take(), "next:stdout", log.clone());
+    pipe_process_output(child.stderr.take(), "next:stderr", log.clone());
 
     {
         let state = app.state::<ServerState>();
@@ -163,10 +183,16 @@ fn start_next_server(app: &AppHandle) -> Result<u16, String> {
     }
 
     if wait_until_ready(port, Duration::from_secs(60)) {
+        log_line(log.as_ref(), "[startup] server ready");
         Ok(port)
     } else {
         stop_next_server(app);
-        Err("服务器启动超时，请检查 Node.js、Prisma 或端口占用状态。".to_string())
+        let msg = format!(
+            "服务器启动超时，请检查 Node.js、Prisma 或端口占用状态。启动日志：{}",
+            log_path.display()
+        );
+        log_line(log.as_ref(), "[startup] timeout: server did not become ready within 60s");
+        Err(msg)
     }
 }
 
@@ -181,6 +207,42 @@ fn stop_next_server(app: &AppHandle) {
         let _ = child.wait();
     }
     runtime.port = None;
+}
+
+fn log_line(log: Option<&Arc<Mutex<fs::File>>>, message: &str) {
+    if let Some(log) = log {
+        if let Ok(mut f) = log.lock() {
+            let _ = writeln!(f, "{message}");
+        }
+    }
+}
+
+fn write_startup_header(
+    log: Option<&Arc<Mutex<fs::File>>>,
+    standalone_dir: &PathBuf,
+    node_binary: &PathBuf,
+    using_bundled: bool,
+    port: u16,
+    database_path: &PathBuf,
+    log_path: &PathBuf,
+) {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    log_line(log, &format!("=== OSE startup (unix={ts}) ==="));
+    log_line(log, &format!("log:          {}", log_path.display()));
+    log_line(log, &format!("standalone:   {}", standalone_dir.display()));
+    log_line(
+        log,
+        &format!(
+            "node:         {} (bundled={})",
+            node_binary.display(),
+            using_bundled
+        ),
+    );
+    log_line(log, &format!("port:         {port}"));
+    log_line(log, &format!("database:     {}", database_path.display()));
 }
 
 fn resolve_node_binary(standalone_dir: &PathBuf) -> PathBuf {
@@ -271,7 +333,7 @@ fn health_check(port: u16) -> bool {
     BufReader::new(stream).read_line(&mut first_line).is_ok() && first_line.contains("200")
 }
 
-fn pipe_process_output<T>(pipe: Option<T>, label: &'static str)
+fn pipe_process_output<T>(pipe: Option<T>, label: &'static str, log: Option<Arc<Mutex<fs::File>>>)
 where
     T: std::io::Read + Send + 'static,
 {
@@ -279,6 +341,11 @@ where
         thread::spawn(move || {
             for line in BufReader::new(pipe).lines().map_while(Result::ok) {
                 println!("[{label}] {line}");
+                if let Some(ref log) = log {
+                    if let Ok(mut f) = log.lock() {
+                        let _ = writeln!(f, "[{label}] {line}");
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
Partially addresses #7.

## Changes

- `src-tauri/src/lib.rs`: write sidecar stdout/stderr and startup context to `startup.log` in app data dir; include log path in timeout errors
- `package.json`: expose `npm run verify:portable`
- `docs/desktop-app.md`: add Portable Zip section with layout, BUNDLE_NODE=1 requirement, known limitations, and startup log locations

Generated with [Claude Code](https://claude.ai/code)