### PR TITLE
feat(ai): support image questions in AI deep explanation

### DIFF
--- a/src/app/api/ai/explain/route.ts
+++ b/src/app/api/ai/explain/route.ts
@@ -1,8 +1,8 @@
 ﻿import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { getAIProvider, isAIConfigured } from "@/lib/ai";
+import { buildAIProvider, isAIConfigured, resolveAIConfig } from "@/lib/ai";
 import { checkAIRateLimit } from "@/lib/ai/rate-limit";
-import { createAIErrorResponse, streamText } from "@/lib/ai/utils";
+import { createAIErrorResponse, extractImageUrls, streamText } from "@/lib/ai/utils";
 import { EXPLAIN_SYSTEM_PROMPT, buildExplainUserMessage } from "@/lib/ai/prompts";
 import { prisma } from "@/lib/prisma";
 
@@ -20,8 +20,28 @@ export async function POST(request: Request) {
     if (!question) return NextResponse.json({ message: "题目不存在" }, { status: 404 });
     const selected = question.options.find((option) => option.id === userAnswerOptionId);
     const userMessage = buildExplainUserMessage(question, selected?.label ?? "未选择", Boolean(selected?.isCorrect));
-    const provider = await getAIProvider(userId);
-    return streamText(provider.streamCompletion({ systemPrompt: EXPLAIN_SYSTEM_PROMPT, userMessage, maxTokens: 1600, temperature: 0.2 }));
+
+    const allContent = [question.content, ...question.options.map((o) => o.content)].join("\n");
+    const imageUrls = extractImageUrls(allContent);
+
+    const config = await resolveAIConfig(userId);
+    if (!config) return NextResponse.json({ message: "请在个人中心填入 API Key 或设置环境变量以启用 AI" }, { status: 503 });
+    const provider = buildAIProvider(config);
+
+    if (imageUrls.length > 0 && !provider.supportsVision()) {
+      const { model } = provider.getInfo();
+      return NextResponse.json({
+        message: `当前配置的模型（${model}）不支持视觉输入，无法分析题目中的图片。如需对含图题进行 AI 深度讲解，请在个人中心切换支持视觉的模型（如 claude-sonnet-4-5、gpt-4o、gemini-2.5-flash 等）。`,
+      }, { status: 422 });
+    }
+
+    return streamText(provider.streamCompletion({
+      systemPrompt: EXPLAIN_SYSTEM_PROMPT,
+      userMessage,
+      maxTokens: 1600,
+      temperature: 0.2,
+      ...(imageUrls.length > 0 ? { imageUrls } : {}),
+    }));
   } catch (error) {
     return createAIErrorResponse(error);
   }

--- a/src/lib/ai/providers/claude.ts
+++ b/src/lib/ai/providers/claude.ts
@@ -9,7 +9,15 @@ function buildMessages(params: CompletionParams): Anthropic.MessageParam[] {
   if (params.messages?.length) {
     return params.messages.map((message) => ({ role: message.role, content: message.content }));
   }
-  return [{ role: "user", content: params.userMessage }];
+  if (!params.imageUrls?.length) {
+    return [{ role: "user", content: params.userMessage }];
+  }
+  const content: Anthropic.ContentBlockParam[] = params.imageUrls.map((url) => ({
+    type: "image" as const,
+    source: { type: "url" as const, url },
+  }));
+  content.push({ type: "text", text: params.userMessage });
+  return [{ role: "user", content }];
 }
 
 export function createClaudeProvider(config: AIConfig): AIProvider {
@@ -24,6 +32,7 @@ export function createClaudeProvider(config: AIConfig): AIProvider {
 
   return {
     name: "Claude",
+    supportsVision: () => true,
     getInfo() {
       return {
         name: "Claude",

--- a/src/lib/ai/providers/custom.ts
+++ b/src/lib/ai/providers/custom.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import type { ChatCompletionContentPart, ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
 import { getSanitizedEndpoint, normalizeErrorMessage } from "@/lib/ai/utils";
 
@@ -12,9 +12,20 @@ function buildMessages(params: CompletionParams): ChatCompletionMessageParam[] {
       ...params.messages.map((message) => ({ role: message.role, content: message.content }) as ChatCompletionMessageParam),
     ];
   }
+  if (!params.imageUrls?.length) {
+    return [
+      { role: "system", content: params.systemPrompt },
+      { role: "user", content: params.userMessage },
+    ];
+  }
+  const parts: ChatCompletionContentPart[] = params.imageUrls.map((url) => ({
+    type: "image_url" as const,
+    image_url: { url },
+  }));
+  parts.push({ type: "text", text: params.userMessage });
   return [
     { role: "system", content: params.systemPrompt },
-    { role: "user", content: params.userMessage },
+    { role: "user", content: parts },
   ];
 }
 
@@ -40,6 +51,7 @@ export function createCustomProvider(config: AIConfig): AIProvider {
 
   return {
     name: "Custom",
+    supportsVision: () => true,
     getInfo() {
       if (!baseUrl) throw new Error("使用 custom 供应商时必须配置 Base URL");
       return {

--- a/src/lib/ai/providers/gemini.ts
+++ b/src/lib/ai/providers/gemini.ts
@@ -1,18 +1,26 @@
 import { GoogleGenAI } from "@google/genai";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
-import { getSanitizedEndpoint } from "@/lib/ai/utils";
+import { fetchImageAsBase64, getSanitizedEndpoint } from "@/lib/ai/utils";
 
 const defaultModel = "gemini-2.5-flash";
 const defaultBaseUrl = "https://generativelanguage.googleapis.com";
 
-function buildContents(params: CompletionParams) {
+async function buildContents(params: CompletionParams) {
   if (params.messages?.length) {
     return params.messages.map((message) => ({
       role: message.role === "assistant" ? "model" : "user",
       parts: [{ text: message.content }],
     }));
   }
-  return params.userMessage;
+  if (!params.imageUrls?.length) return params.userMessage;
+
+  const parts: Array<{ text?: string; inlineData?: { mimeType: string; data: string } }> = [];
+  for (const url of params.imageUrls) {
+    const result = await fetchImageAsBase64(url);
+    if (result) parts.push({ inlineData: { mimeType: result.mimeType, data: result.base64 } });
+  }
+  parts.push({ text: params.userMessage });
+  return [{ role: "user", parts }];
 }
 
 export function createGeminiProvider(config: AIConfig): AIProvider {
@@ -27,6 +35,7 @@ export function createGeminiProvider(config: AIConfig): AIProvider {
 
   return {
     name: "Gemini",
+    supportsVision: () => true,
     getInfo() {
       return {
         name: "Gemini",
@@ -37,7 +46,7 @@ export function createGeminiProvider(config: AIConfig): AIProvider {
     async createCompletion(params) {
       const response = await getClient().models.generateContent({
         model,
-        contents: buildContents(params),
+        contents: await buildContents(params),
         config: {
           systemInstruction: params.systemPrompt,
           maxOutputTokens: params.maxTokens ?? 1200,
@@ -49,7 +58,7 @@ export function createGeminiProvider(config: AIConfig): AIProvider {
     async *streamCompletion(params) {
       const response = await getClient().models.generateContentStream({
         model,
-        contents: buildContents(params),
+        contents: await buildContents(params),
         config: {
           systemInstruction: params.systemPrompt,
           maxOutputTokens: params.maxTokens ?? 1200,

--- a/src/lib/ai/providers/openai.ts
+++ b/src/lib/ai/providers/openai.ts
@@ -1,10 +1,20 @@
 import OpenAI from "openai";
-import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import type { ChatCompletionContentPart, ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
 import { getSanitizedEndpoint } from "@/lib/ai/utils";
 
 const defaultBaseUrl = "https://api.openai.com/v1";
 const defaultModel = "gpt-4o-mini";
+
+function isVisionCapableModel(model: string): boolean {
+  const m = model.toLowerCase();
+  if (m.includes("gpt-4o")) return true;
+  if (m.includes("gpt-4-turbo")) return true;
+  if (m.includes("gpt-4-vision")) return true;
+  if (m.includes("gpt-4.5")) return true;
+  if (/\bo[134][-\s]/.test(m) || m === "o1" || m === "o3" || m === "o4") return true;
+  return false;
+}
 
 function buildMessages(params: CompletionParams): ChatCompletionMessageParam[] {
   if (params.messages?.length) {
@@ -13,9 +23,20 @@ function buildMessages(params: CompletionParams): ChatCompletionMessageParam[] {
       ...params.messages.map((message) => ({ role: message.role, content: message.content }) as ChatCompletionMessageParam),
     ];
   }
+  if (!params.imageUrls?.length) {
+    return [
+      { role: "system", content: params.systemPrompt },
+      { role: "user", content: params.userMessage },
+    ];
+  }
+  const parts: ChatCompletionContentPart[] = params.imageUrls.map((url) => ({
+    type: "image_url" as const,
+    image_url: { url },
+  }));
+  parts.push({ type: "text", text: params.userMessage });
   return [
     { role: "system", content: params.systemPrompt },
-    { role: "user", content: params.userMessage },
+    { role: "user", content: parts },
   ];
 }
 
@@ -31,6 +52,7 @@ export function createOpenAIProvider(config: AIConfig): AIProvider {
 
   return {
     name: "OpenAI",
+    supportsVision: () => isVisionCapableModel(model),
     getInfo() {
       return {
         name: "OpenAI",

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -9,6 +9,7 @@ export interface CompletionParams {
   messages?: AIMessage[];
   maxTokens?: number;
   temperature?: number;
+  imageUrls?: string[];
 }
 
 export interface AIProviderInfo {
@@ -31,4 +32,5 @@ export interface AIProvider {
   getInfo(): AIProviderInfo;
   createCompletion(params: CompletionParams): Promise<string>;
   streamCompletion(params: CompletionParams): AsyncIterable<string>;
+  supportsVision(): boolean;
 }

--- a/src/lib/ai/utils.ts
+++ b/src/lib/ai/utils.ts
@@ -101,3 +101,40 @@ export function streamText(iterator: AsyncIterable<string>) {
 export function cleanJsonText(text: string) {
   return text.replace(/^```json\s*/i, "").replace(/^```\s*/i, "").replace(/```$/i, "").trim();
 }
+
+export function extractImageUrls(content: string): string[] {
+  const urls: string[] = [];
+  const imgTagRegex = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi;
+  let match;
+  while ((match = imgTagRegex.exec(content)) !== null) {
+    try {
+      const url = new URL(match[1]);
+      if (url.protocol === "http:" || url.protocol === "https:") urls.push(match[1]);
+    } catch { /* skip invalid */ }
+  }
+  const markdownImgRegex = /!\[[^\]]*\]\(([^)\s]+)\)/g;
+  while ((match = markdownImgRegex.exec(content)) !== null) {
+    try {
+      const url = new URL(match[1]);
+      if (url.protocol === "http:" || url.protocol === "https:") urls.push(match[1]);
+    } catch { /* skip invalid */ }
+  }
+  return [...new Set(urls)];
+}
+
+export async function fetchImageAsBase64(url: string): Promise<{ base64: string; mimeType: string } | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!response.ok) return null;
+    const contentType = response.headers.get("content-type") ?? "image/jpeg";
+    const mimeType = contentType.split(";")[0].trim() || "image/jpeg";
+    const buffer = await response.arrayBuffer();
+    const base64 = Buffer.from(buffer).toString("base64");
+    return { base64, mimeType };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #9

Extract image URLs from question content and options, pass them as multimodal inputs to the AI provider.

- Claude/OpenAI/Custom: images passed as URL-based content parts
- Gemini: images fetched server-side and passed as base64 inlineData
- OpenAI: vision support detected from model name
- When model does not support vision, returns HTTP 422 with clear message instead of letting the model ask users to re-upload images

Generated with [Claude Code](https://claude.ai/code)