### PR TITLE
feat: persist AI deep explanation in wrong notes with status tracking & regeneration

### DIFF
--- a/src/app/api/ai/wrong-note-explanation/route.ts
+++ b/src/app/api/ai/wrong-note-explanation/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+
+import { auth } from '@/lib/auth';
+import { createAIErrorResponse } from '@/lib/ai/utils';
+import {
+  getLatestWrongNoteExplanationGeneration,
+  prepareAndRunWrongNoteExplanation,
+  serializeExplanationGeneration,
+} from '@/lib/ai/wrong-note-explanation';
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ message: '请先登录' }, { status: 401 });
+  const userId = session.user.id;
+  const { searchParams } = new URL(request.url);
+  const wrongNoteId = String(searchParams.get('wrongNoteId') ?? '');
+  if (!wrongNoteId) return NextResponse.json({ message: '参数不完整' }, { status: 400 });
+
+  try {
+    const generation = await getLatestWrongNoteExplanationGeneration(userId, wrongNoteId);
+    return NextResponse.json({
+      generation: generation ? serializeExplanationGeneration(generation) : null,
+    });
+  } catch (error) {
+    return createAIErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ message: '请先登录' }, { status: 401 });
+  const userId = session.user.id;
+  const body = await request.json().catch(() => ({}));
+  const wrongNoteId = String((body as { wrongNoteId?: unknown }).wrongNoteId ?? '');
+  const force = Boolean((body as { force?: unknown }).force);
+  if (!wrongNoteId) return NextResponse.json({ message: '参数不完整' }, { status: 400 });
+
+  try {
+    const { generation, reused } = await prepareAndRunWrongNoteExplanation({
+      userId,
+      wrongNoteId,
+      force,
+    });
+    return NextResponse.json({ generation: serializeExplanationGeneration(generation), reused });
+  } catch (error) {
+    const withGeneration = error as { generation?: unknown };
+    if (withGeneration.generation) {
+      return NextResponse.json(
+        {
+          message:
+            error instanceof Error ? error.message : 'AI 深度讲解生成失败，请稍后重试',
+          generation: serializeExplanationGeneration(
+            withGeneration.generation as Parameters<typeof serializeExplanationGeneration>[0]
+          ),
+        },
+        { status: 502 }
+      );
+    }
+    return createAIErrorResponse(error);
+  }
+}

--- a/src/app/api/wrong-notes/route.ts
+++ b/src/app/api/wrong-notes/route.ts
@@ -85,35 +85,62 @@ export async function GET(request: Request) {
   ]);
 
   const wrongNoteIds = notes.map((note) => note.id);
-  const imageGenerations = wrongNoteIds.length
-    ? await prisma.aIImageGeneration.findMany({
-        where: { userId, wrongNoteId: { in: wrongNoteIds } },
-        orderBy: { updatedAt: 'desc' },
-        select: {
-          id: true,
-          wrongNoteId: true,
-          status: true,
-          provider: true,
-          model: true,
-          promptProvider: true,
-          promptModel: true,
-          imageSize: true,
-          imageQuality: true,
-          imageOutputFormat: true,
-          imageStyle: true,
-          imagePath: true,
-          errorMessage: true,
-          createdAt: true,
-          updatedAt: true,
-          completedAt: true,
-        },
-      })
-    : [];
+  const [imageGenerations, explanationGenerations] = wrongNoteIds.length
+    ? await Promise.all([
+        prisma.aIImageGeneration.findMany({
+          where: { userId, wrongNoteId: { in: wrongNoteIds } },
+          orderBy: { updatedAt: 'desc' },
+          select: {
+            id: true,
+            wrongNoteId: true,
+            status: true,
+            provider: true,
+            model: true,
+            promptProvider: true,
+            promptModel: true,
+            imageSize: true,
+            imageQuality: true,
+            imageOutputFormat: true,
+            imageStyle: true,
+            imagePath: true,
+            errorMessage: true,
+            createdAt: true,
+            updatedAt: true,
+            completedAt: true,
+          },
+        }),
+        prisma.aIExplanationGeneration.findMany({
+          where: { userId, wrongNoteId: { in: wrongNoteIds } },
+          orderBy: { updatedAt: 'desc' },
+          select: {
+            id: true,
+            wrongNoteId: true,
+            status: true,
+            provider: true,
+            model: true,
+            errorMessage: true,
+            createdAt: true,
+            updatedAt: true,
+            completedAt: true,
+          },
+        }),
+      ])
+    : [[], []];
+
   const imageGenerationsByWrongNote = new Map<string, typeof imageGenerations>();
   for (const generation of imageGenerations) {
     if (!generation.wrongNoteId) continue;
     imageGenerationsByWrongNote.set(generation.wrongNoteId, [
       ...(imageGenerationsByWrongNote.get(generation.wrongNoteId) ?? []),
+      generation,
+    ]);
+  }
+
+  const explanationGenerationsByWrongNote = new Map<string, typeof explanationGenerations>();
+  for (const generation of explanationGenerations) {
+    if (!generation.wrongNoteId) continue;
+    explanationGenerationsByWrongNote.set(generation.wrongNoteId, [
+      ...(explanationGenerationsByWrongNote.get(generation.wrongNoteId) ?? []),
       generation,
     ]);
   }
@@ -129,6 +156,13 @@ export async function GET(request: Request) {
       ) ??
       generations.find((generation) => generation.status === 'COMPLETED' && generation.imagePath) ??
       generations.find((generation) => generation.status === 'FAILED') ??
+      null;
+
+    const expGenerations = explanationGenerationsByWrongNote.get(note.id) ?? [];
+    const explanationGeneration =
+      expGenerations.find((g) => g.status === 'PENDING' || g.status === 'RUNNING') ??
+      expGenerations.find((g) => g.status === 'COMPLETED') ??
+      expGenerations.find((g) => g.status === 'FAILED') ??
       null;
     return {
       id: note.id,
@@ -163,6 +197,18 @@ export async function GET(request: Request) {
             createdAt: imageGeneration.createdAt,
             updatedAt: imageGeneration.updatedAt,
             completedAt: imageGeneration.completedAt,
+          }
+        : null,
+      explanationGeneration: explanationGeneration
+        ? {
+            id: explanationGeneration.id,
+            status: explanationGeneration.status,
+            provider: explanationGeneration.provider,
+            model: explanationGeneration.model,
+            errorMessage: explanationGeneration.errorMessage,
+            createdAt: explanationGeneration.createdAt,
+            updatedAt: explanationGeneration.updatedAt,
+            completedAt: explanationGeneration.completedAt,
           }
         : null,
       question: {

--- a/src/components/ai-wrong-note-explanation-button.tsx
+++ b/src/components/ai-wrong-note-explanation-button.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { Lightbulb, Loader2, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { ContinueAIChatButton } from '@/components/continue-ai-chat-button';
+import { MarkdownRenderer } from '@/components/markdown-renderer';
+import { VariantQuestions } from '@/components/variant-questions';
+import { useAIStatus } from '@/components/ai-status-context';
+import { showToast } from '@/lib/toast-client';
+import { cn } from '@/lib/utils';
+
+type ExplanationStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+
+type ExplanationGeneration = {
+  id: string;
+  status: ExplanationStatus;
+  content?: string | null;
+  errorMessage: string | null;
+  provider?: string;
+  model?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  completedAt?: string | null;
+};
+
+type AIWrongNoteExplanationButtonProps = {
+  wrongNoteId: string;
+  questionId: string;
+  userAnswerOptionId?: string;
+  initialGeneration?: ExplanationGeneration | null;
+  onGenerationChange?: (generation: ExplanationGeneration | null) => void;
+};
+
+function isActiveStatus(status: ExplanationStatus | undefined) {
+  return status === 'PENDING' || status === 'RUNNING';
+}
+
+export function AIWrongNoteExplanationButton({
+  wrongNoteId,
+  questionId,
+  userAnswerOptionId,
+  initialGeneration,
+  onGenerationChange,
+}: AIWrongNoteExplanationButtonProps) {
+  const aiStatus = useAIStatus();
+  const [generation, setGeneration] = useState<ExplanationGeneration | null>(
+    initialGeneration ?? null
+  );
+  const [loading, setLoading] = useState(!initialGeneration);
+  const [submitting, setSubmitting] = useState(false);
+  const controllerRef = useRef<AbortController | null>(null);
+  const hasInitialRef = useRef(Boolean(initialGeneration));
+  const initialKey = initialGeneration
+    ? `${initialGeneration.id}:${initialGeneration.status}`
+    : '';
+
+  useEffect(() => {
+    if (initialGeneration) setGeneration(initialGeneration);
+  }, [initialGeneration, initialKey]);
+
+  const load = useCallback(
+    async (options?: { silent?: boolean }) => {
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      if (!options?.silent) setLoading(true);
+      try {
+        const response = await fetch(
+          `/api/ai/wrong-note-explanation?wrongNoteId=${encodeURIComponent(wrongNoteId)}`,
+          { cache: 'no-store', signal: controller.signal }
+        );
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) return;
+        const next = ((data as { generation?: ExplanationGeneration | null }).generation ??
+          null) as ExplanationGeneration | null;
+        setGeneration((current) => {
+          if (next) return next;
+          if (current?.status === 'COMPLETED' && current.content) return current;
+          return null;
+        });
+        if (next) onGenerationChange?.(next);
+      } catch (error) {
+        if ((error as { name?: string })?.name === 'AbortError') return;
+      } finally {
+        if (controllerRef.current === controller) controllerRef.current = null;
+        if (!options?.silent) setLoading(false);
+      }
+    },
+    [onGenerationChange, wrongNoteId]
+  );
+
+  useEffect(() => {
+    load({ silent: hasInitialRef.current });
+    return () => controllerRef.current?.abort();
+  }, [load]);
+
+  useEffect(() => {
+    if (!isActiveStatus(generation?.status)) return;
+    const timer = window.setInterval(() => {
+      void load({ silent: true });
+    }, 2200);
+    return () => window.clearInterval(timer);
+  }, [generation?.status, load]);
+
+  async function generate(force = false) {
+    if (!aiStatus.configured) return;
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/ai/wrong-note-explanation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ wrongNoteId, force }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const msg = (data as { message?: string }).message || 'AI 深度讲解生成失败';
+        showToast({ title: 'AI 深度讲解失败', description: msg });
+        if ((data as { generation?: ExplanationGeneration }).generation) {
+          const next = (data as { generation: ExplanationGeneration }).generation;
+          setGeneration(next);
+          onGenerationChange?.(next);
+        }
+        return;
+      }
+      const next = (data as { generation: ExplanationGeneration }).generation;
+      setGeneration(next);
+      onGenerationChange?.(next);
+      if (next.status === 'COMPLETED') {
+        showToast({ title: force ? 'AI 讲解已重新生成' : 'AI 深度讲解已生成' });
+      }
+    } catch {
+      showToast({ title: '网络异常', description: '请稍后再试' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const active = isActiveStatus(generation?.status);
+  const completed = generation?.status === 'COMPLETED' && Boolean(generation?.content);
+  const failed = generation?.status === 'FAILED';
+  const disabled = loading || submitting || active || !aiStatus.configured;
+
+  return (
+    <div className="mt-5">
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant={completed ? 'secondary' : 'default'}
+          onClick={() => generate(completed || failed)}
+          disabled={disabled}
+          title={!aiStatus.configured ? '请先配置文本 AI，生图 AI 不会启用文字讲解' : undefined}
+        >
+          {loading || submitting || active ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : completed || failed ? (
+            <RefreshCw className="h-4 w-4" />
+          ) : (
+            <Lightbulb className="h-4 w-4" />
+          )}
+          {loading
+            ? '加载讲解...'
+            : submitting
+              ? 'AI 正在生成讲解...'
+              : active
+                ? 'AI 深度讲解生成中...'
+                : completed
+                  ? '重新生成 AI 讲解'
+                  : failed
+                    ? '重试 AI 讲解'
+                    : aiStatus.configured
+                      ? 'AI 深度讲解'
+                      : '未配置文本 AI'}
+        </Button>
+        {!aiStatus.configured ? (
+          <Button asChild variant="ghost">
+            <Link href="/profile">去配置</Link>
+          </Button>
+        ) : null}
+        {generation?.status ? (
+          <span
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-black',
+              generation.status === 'COMPLETED' && 'bg-green-100 text-green-700',
+              active && 'bg-amber-100 text-amber-700',
+              generation.status === 'FAILED' && 'bg-red-100 text-red-600'
+            )}
+          >
+            {generation.status === 'PENDING'
+              ? 'AI 讲解排队中'
+              : generation.status === 'RUNNING'
+                ? 'AI 讲解生成中'
+                : generation.status === 'COMPLETED'
+                  ? 'AI 讲解已生成'
+                  : 'AI 讲解生成失败'}
+          </span>
+        ) : null}
+      </div>
+
+      {!aiStatus.configured ? (
+        <p className="mt-3 rounded-2xl bg-softYellow px-4 py-3 text-sm font-bold text-muted">
+          AI 深度讲解需要配置文本 AI；生图 AI 只用于错题讲解图。
+        </p>
+      ) : null}
+
+      {failed && generation.errorMessage ? (
+        <p className="mt-3 rounded-2xl bg-red-50 px-4 py-3 text-sm font-black text-red-600">
+          {generation.errorMessage}
+        </p>
+      ) : null}
+
+      {completed && generation.content ? (
+        <Card className="mt-4 bg-softYellow/60 p-5 hover:translate-y-0">
+          <div className="mb-4 flex justify-end">
+            <ContinueAIChatButton
+              title="AI 深度讲解"
+              messages={[
+                {
+                  role: 'user',
+                  content: `请对这道题进行 AI 深度讲解。题目 ID：${questionId}${userAnswerOptionId ? `，我的选项 ID：${userAnswerOptionId}` : ''}`,
+                },
+                { role: 'assistant', content: generation.content ?? '' },
+              ]}
+            />
+          </div>
+          <MarkdownRenderer content={generation.content ?? ''} />
+          <VariantQuestions questionId={questionId} />
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/wrong-notes-client.tsx
+++ b/src/components/wrong-notes-client.tsx
@@ -15,7 +15,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
-import { AIExplainButton } from '@/components/ai-explain-button';
+import { AIWrongNoteExplanationButton } from '@/components/ai-wrong-note-explanation-button';
 import { AIWrongNoteImageButton } from '@/components/ai-wrong-note-image-button';
 import { MarkdownRenderer } from '@/components/markdown-renderer';
 import { OSESelect } from '@/components/ose-select';
@@ -23,6 +23,18 @@ import { showToast } from '@/lib/toast-client';
 import { WRONG_NOTE_PREVIEW_LENGTH } from '@/lib/constants';
 
 type Topic = { id: string; name: string; parentId?: string | null };
+type WrongNoteExplanationStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+type WrongNoteExplanationGeneration = {
+  id: string;
+  status: WrongNoteExplanationStatus;
+  content?: string | null;
+  provider?: string;
+  model?: string;
+  errorMessage: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  completedAt?: string | null;
+};
 type WrongItem = {
   id: string;
   markedMastered: boolean;
@@ -31,6 +43,7 @@ type WrongItem = {
   wrongOptionId?: string;
   correctOption?: { id: string; label: string; content: string };
   imageGeneration: WrongNoteImageGeneration | null;
+  explanationGeneration: WrongNoteExplanationGeneration | null;
   question: {
     id: string;
     content: string;
@@ -96,6 +109,25 @@ function imageStatusLabel(generation?: WrongNoteImageGeneration | null) {
 function imageStatusClass(generation?: WrongNoteImageGeneration | null) {
   if (generation?.status === 'COMPLETED') return 'bg-green-100 text-green-700';
   if (isActiveImageStatus(generation?.status)) return 'bg-amber-100 text-amber-700';
+  if (generation?.status === 'FAILED') return 'bg-red-100 text-red-600';
+  return 'bg-gray-100 text-muted';
+}
+
+function isActiveExplanationStatus(status: WrongNoteExplanationStatus | undefined) {
+  return status === 'PENDING' || status === 'RUNNING';
+}
+
+function explanationStatusLabel(generation?: WrongNoteExplanationGeneration | null) {
+  if (generation?.status === 'PENDING') return 'AI 讲解排队中';
+  if (generation?.status === 'RUNNING') return 'AI 讲解生成中';
+  if (generation?.status === 'COMPLETED') return '已有 AI 讲解';
+  if (generation?.status === 'FAILED') return 'AI 讲解失败';
+  return '暂无 AI 讲解';
+}
+
+function explanationStatusClass(generation?: WrongNoteExplanationGeneration | null) {
+  if (generation?.status === 'COMPLETED') return 'bg-blue-100 text-blue-700';
+  if (isActiveExplanationStatus(generation?.status)) return 'bg-amber-100 text-amber-700';
   if (generation?.status === 'FAILED') return 'bg-red-100 text-red-600';
   return 'bg-gray-100 text-muted';
 }
@@ -314,6 +346,24 @@ export function WrongNotesClient() {
     []
   );
 
+  const updateExplanationGeneration = useCallback(
+    (id: string, generation: WrongNoteExplanationGeneration | null) => {
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              items: prev.items.map((item) =>
+                item.id === id && generation
+                  ? { ...item, explanationGeneration: generation }
+                  : item
+              ),
+            }
+          : prev
+      );
+    },
+    []
+  );
+
   async function retryAll() {
     try {
       const response = await fetch('/api/wrong-notes/retry', { method: 'POST' });
@@ -441,6 +491,7 @@ export function WrongNotesClient() {
             key={item.id}
             item={item}
             onImageGenerationChange={updateImageGeneration}
+            onExplanationGenerationChange={updateExplanationGeneration}
             onToggle={patchNote}
             onDelete={deleteNote}
           />
@@ -474,6 +525,10 @@ export function WrongNotesClient() {
 type RowProps = {
   item: WrongItem;
   onImageGenerationChange: (id: string, generation: WrongNoteImageGeneration | null) => void;
+  onExplanationGenerationChange: (
+    id: string,
+    generation: WrongNoteExplanationGeneration | null
+  ) => void;
   onToggle: (id: string, mastered: boolean) => void;
   onDelete: (id: string) => void;
 };
@@ -481,6 +536,7 @@ type RowProps = {
 const WrongNoteRow = memo(function WrongNoteRow({
   item,
   onImageGenerationChange,
+  onExplanationGenerationChange,
   onToggle,
   onDelete,
 }: RowProps) {
@@ -506,6 +562,13 @@ const WrongNoteRow = memo(function WrongNoteRow({
       onImageGenerationChange(item.id, generation);
     },
     [item.id, onImageGenerationChange]
+  );
+
+  const handleExplanationGenerationChange = useCallback(
+    (generation: WrongNoteExplanationGeneration | null) => {
+      onExplanationGenerationChange(item.id, generation);
+    },
+    [item.id, onExplanationGenerationChange]
   );
 
   async function submitRetry() {
@@ -559,6 +622,15 @@ const WrongNoteRow = memo(function WrongNoteRow({
               title={item.imageGeneration?.errorMessage ?? undefined}
             >
               {imageStatusLabel(item.imageGeneration)}
+            </span>
+            <span
+              className={cn(
+                'rounded-full px-3 py-1 text-xs font-black',
+                explanationStatusClass(item.explanationGeneration)
+              )}
+              title={item.explanationGeneration?.errorMessage ?? undefined}
+            >
+              {explanationStatusLabel(item.explanationGeneration)}
             </span>
           </div>
           <h2 className="font-black leading-relaxed text-navy">{preview}</h2>
@@ -645,9 +717,12 @@ const WrongNoteRow = memo(function WrongNoteRow({
             <div className="mt-5 rounded-3xl bg-white p-5 shadow-soft">
               <p className="font-black text-navy">解析</p>
               <p className="mt-2 font-semibold leading-7 text-muted">{item.question.explanation}</p>
-              <AIExplainButton
+              <AIWrongNoteExplanationButton
+                wrongNoteId={item.id}
                 questionId={item.question.id}
                 userAnswerOptionId={item.wrongOptionId}
+                initialGeneration={item.explanationGeneration}
+                onGenerationChange={handleExplanationGenerationChange}
               />
               <AIWrongNoteImageButton
                 wrongNoteId={item.id}

--- a/src/lib/ai/wrong-note-explanation.ts
+++ b/src/lib/ai/wrong-note-explanation.ts
@@ -1,0 +1,190 @@
+import { buildAIProvider, resolveAIConfig } from '@/lib/ai';
+import { checkAIRateLimit } from '@/lib/ai/rate-limit';
+import { EXPLAIN_SYSTEM_PROMPT, buildExplainUserMessage } from '@/lib/ai/prompts';
+import { extractImageUrls, normalizeErrorMessage } from '@/lib/ai/utils';
+import { prisma } from '@/lib/prisma';
+
+type SerializedExplanationGeneration = {
+  id: string;
+  status: string;
+  content: string | null;
+  errorMessage: string | null;
+  provider: string;
+  model: string;
+  createdAt: Date;
+  updatedAt: Date;
+  completedAt: Date | null;
+};
+
+type GenerationForSerialization = {
+  id: string;
+  status: string;
+  content: string | null;
+  errorMessage: string | null;
+  provider: string;
+  model: string;
+  createdAt: Date;
+  updatedAt: Date;
+  completedAt: Date | null;
+};
+
+export function serializeExplanationGeneration(
+  generation: GenerationForSerialization
+): SerializedExplanationGeneration {
+  return {
+    id: generation.id,
+    status: generation.status,
+    content: generation.status === 'COMPLETED' ? generation.content : null,
+    errorMessage: generation.errorMessage,
+    provider: generation.provider,
+    model: generation.model,
+    createdAt: generation.createdAt,
+    updatedAt: generation.updatedAt,
+    completedAt: generation.completedAt,
+  };
+}
+
+async function getWrongNoteContext(userId: string, wrongNoteId: string) {
+  const note = await prisma.wrongNote.findFirst({
+    where: { id: wrongNoteId, userId },
+    include: {
+      question: {
+        include: {
+          options: { orderBy: { label: 'asc' } },
+          userAnswers: {
+            where: { userId },
+            orderBy: { createdAt: 'desc' },
+            take: 5,
+            include: { selectedOption: true },
+          },
+        },
+      },
+    },
+  });
+  if (!note) throw Object.assign(new Error('错题不存在'), { status: 404 });
+
+  const latestWrong =
+    note.question.userAnswers.find((answer) => !answer.isCorrect) ?? note.question.userAnswers[0];
+  const wrongOptionId = latestWrong?.selectedOptionId ?? null;
+  const wrongAnswerLabel = latestWrong?.selectedOption?.label ?? '';
+  const isCorrect = latestWrong?.isCorrect ?? false;
+  return { note, wrongOptionId, wrongAnswerLabel, isCorrect };
+}
+
+export async function getLatestWrongNoteExplanationGeneration(userId: string, wrongNoteId: string) {
+  const generations = await prisma.aIExplanationGeneration.findMany({
+    where: { userId, wrongNoteId },
+    orderBy: { updatedAt: 'desc' },
+    take: 10,
+  });
+  return (
+    generations.find((g) => g.status === 'PENDING' || g.status === 'RUNNING') ??
+    generations.find((g) => g.status === 'COMPLETED' && g.content) ??
+    generations.find((g) => g.status === 'FAILED') ??
+    null
+  );
+}
+
+export async function prepareAndRunWrongNoteExplanation(params: {
+  userId: string;
+  wrongNoteId: string;
+  force?: boolean;
+}): Promise<{ generation: GenerationForSerialization; reused: boolean }> {
+  const { note, wrongOptionId, wrongAnswerLabel, isCorrect } = await getWrongNoteContext(
+    params.userId,
+    params.wrongNoteId
+  );
+
+  if (!params.force) {
+    const existing = await prisma.aIExplanationGeneration.findFirst({
+      where: {
+        userId: params.userId,
+        wrongNoteId: params.wrongNoteId,
+        status: { in: ['COMPLETED', 'PENDING', 'RUNNING'] },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (existing) {
+      return { generation: existing, reused: true };
+    }
+  }
+
+  if (!checkAIRateLimit(params.userId))
+    throw Object.assign(new Error('AI 调用太频繁啦，请稍后再试'), { status: 429 });
+
+  const config = await resolveAIConfig(params.userId);
+  if (!config)
+    throw Object.assign(
+      new Error('请在个人中心填入 API Key 或设置环境变量以启用 AI'),
+      { status: 503 }
+    );
+
+  const provider = buildAIProvider(config);
+  const info = provider.getInfo();
+
+  const allContent = [
+    note.question.content,
+    ...note.question.options.map((o) => o.content),
+  ].join('\n');
+  const imageUrls = extractImageUrls(allContent);
+
+  if (imageUrls.length > 0 && !provider.supportsVision()) {
+    const { model } = provider.getInfo();
+    throw Object.assign(
+      new Error(
+        `当前配置的模型（${model}）不支持视觉输入，无法分析题目中的图片。如需对含图题进行 AI 深度讲解，请在个人中心切换支持视觉的模型（如 claude-sonnet-4-5、gpt-4o、gemini-2.5-flash 等）。`
+      ),
+      { status: 422 }
+    );
+  }
+
+  const generation = await prisma.aIExplanationGeneration.create({
+    data: {
+      userId: params.userId,
+      questionId: note.questionId,
+      wrongNoteId: params.wrongNoteId,
+      wrongOptionId,
+      status: 'RUNNING',
+      provider: info.name,
+      model: info.model,
+    },
+  });
+
+  try {
+    const userMessage = buildExplainUserMessage(
+      note.question,
+      wrongAnswerLabel,
+      isCorrect
+    );
+
+    const content = await provider.createCompletion({
+      systemPrompt: EXPLAIN_SYSTEM_PROMPT,
+      userMessage,
+      maxTokens: 1600,
+      temperature: 0.2,
+      ...(imageUrls.length > 0 ? { imageUrls } : {}),
+    });
+
+    const completed = await prisma.aIExplanationGeneration.update({
+      where: { id: generation.id },
+      data: {
+        status: 'COMPLETED',
+        content,
+        completedAt: new Date(),
+      },
+    });
+
+    return { generation: completed, reused: false };
+  } catch (error) {
+    const failed = await prisma.aIExplanationGeneration.update({
+      where: { id: generation.id },
+      data: {
+        status: 'FAILED',
+        errorMessage: normalizeErrorMessage(error).slice(0, 1000),
+      },
+    });
+    throw Object.assign(error instanceof Error ? error : new Error(normalizeErrorMessage(error)), {
+      generation: failed,
+    });
+  }
+}

--- a/src/prisma/migrations/20260502000000_add_ai_explanation_generation/migration.sql
+++ b/src/prisma/migrations/20260502000000_add_ai_explanation_generation/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "AIExplanationGeneration" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "wrongNoteId" TEXT,
+    "wrongOptionId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "provider" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "content" TEXT,
+    "errorMessage" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "completedAt" DATETIME,
+    CONSTRAINT "AIExplanationGeneration_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AIExplanationGeneration_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "Question" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AIExplanationGeneration_wrongNoteId_fkey" FOREIGN KEY ("wrongNoteId") REFERENCES "WrongNote" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "AIExplanationGeneration_userId_createdAt_idx" ON "AIExplanationGeneration"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AIExplanationGeneration_questionId_idx" ON "AIExplanationGeneration"("questionId");
+
+-- CreateIndex
+CREATE INDEX "AIExplanationGeneration_wrongNoteId_status_createdAt_idx" ON "AIExplanationGeneration"("wrongNoteId", "status", "createdAt");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -53,6 +53,13 @@ enum AIImageGenerationStatus {
   FAILED
 }
 
+enum AIExplanationStatus {
+  PENDING
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
 model User {
   id                  String                 @id @default(cuid())
   email               String                 @unique
@@ -67,9 +74,10 @@ model User {
   caseAnswers         UserCaseAnswer[]
   examAttempts        ExamAttempt[]
   studyPlans          StudyPlan[]
-  aiGenerations       AIQuestionGeneration[]
-  aiImageGenerations  AIImageGeneration[]
-  aiChatSessions      AIChatSession[]
+  aiGenerations            AIQuestionGeneration[]
+  aiImageGenerations       AIImageGeneration[]
+  aiExplanationGenerations AIExplanationGeneration[]
+  aiChatSessions           AIChatSession[]
   aiSettings          UserAISettings?
   passwordResetTokens PasswordResetToken[]
 
@@ -141,8 +149,9 @@ model Question {
   options            QuestionOption[]
   userAnswers        UserAnswer[]
   wrongNotes         WrongNote[]
-  aiImageGenerations AIImageGeneration[]
-  practiceSessions   PracticeSessionQuestion[]
+  aiImageGenerations       AIImageGeneration[]
+  aiExplanationGenerations AIExplanationGeneration[]
+  practiceSessions         PracticeSessionQuestion[]
   caseScenario       CaseScenario?
   examQuestions      ExamQuestion[]
   examAnswers        ExamAnswer[]
@@ -257,7 +266,8 @@ model WrongNote {
   updatedAt          DateTime            @updatedAt
   user               User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   question           Question            @relation(fields: [questionId], references: [id], onDelete: Cascade)
-  aiImageGenerations AIImageGeneration[]
+  aiImageGenerations       AIImageGeneration[]
+  aiExplanationGenerations AIExplanationGeneration[]
 
   @@unique([userId, questionId])
   @@index([userId, markedMastered])
@@ -297,6 +307,29 @@ model AIImageGeneration {
   @@index([questionId])
   @@index([wrongNoteId, status, createdAt])
   @@index([fingerprint])
+}
+
+model AIExplanationGeneration {
+  id            String              @id @default(cuid())
+  userId        String
+  questionId    String
+  wrongNoteId   String?
+  wrongOptionId String?
+  status        AIExplanationStatus @default(PENDING)
+  provider      String
+  model         String
+  content       String?
+  errorMessage  String?
+  createdAt     DateTime            @default(now())
+  updatedAt     DateTime            @updatedAt
+  completedAt   DateTime?
+  user          User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  question      Question            @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  wrongNote     WrongNote?          @relation(fields: [wrongNoteId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([questionId])
+  @@index([wrongNoteId, status, createdAt])
 }
 
 model CaseScenario {


### PR DESCRIPTION
Closes #10

## Summary

- Add `AIExplanationGeneration` DB model (PENDING/RUNNING/COMPLETED/FAILED) mirroring the existing image generation pattern
- Add GET/POST `/api/ai/wrong-note-explanation` endpoints for status retrieval and generation
- Wrong notes list API now returns AI explanation status per item
- New `AIWrongNoteExplanationButton` component with generate/view/regenerate/retry UX
- Wrong notes list shows “暂无 AI 讲解 / AI 讲解生成中 / 已有 AI 讲解 / AI 讲解失败” status badge

## Test plan

- [ ] Run `prisma migrate dev` or `prisma migrate deploy` to apply schema changes
- [ ] Run `prisma generate` to update Prisma client
- [ ] Visit /wrong-notes, expand a question, click "AI 深度讲解" and verify the result persists after page refresh
- [ ] Verify the status badge in the list card updates to "已有 AI 讲解"
- [ ] Click "重新生成 AI 讲解" and verify new content replaces the old
- [ ] Test with a question containing images and a non-vision model to verify the error message

Generated with [Claude Code](https://claude.ai/code)