### PR TITLE
fix: use User.targetExamDate for exam countdown in AI diagnosis

### DIFF
--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -2,6 +2,7 @@
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getUserAnalysis } from '@/lib/analysis';
+import { prisma } from '@/lib/prisma';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { AIDiagnosisButton } from '@/components/ai-diagnosis-button';
@@ -17,7 +18,9 @@ function heat(status: string) {
 export default async function AnalysisPage() {
   const session = await auth();
   if (!session?.user?.id) redirect('/login');
-  const data = await getUserAnalysis(session.user.id);
+  const userId = session.user.id;
+  const pageUser = await prisma.user.findUnique({ where: { id: userId }, select: { targetExamDate: true } });
+  const data = await getUserAnalysis(userId, pageUser?.targetExamDate);
   const maxCount = Math.max(1, ...data.trend.map((day) => day.count));
   return (
     <main className="mx-auto mt-6 max-w-7xl space-y-6 md:mt-8 md:space-y-8">

--- a/src/app/api/ai/diagnosis/route.ts
+++ b/src/app/api/ai/diagnosis/route.ts
@@ -5,6 +5,7 @@ import { checkAIRateLimit } from "@/lib/ai/rate-limit";
 import { createAIErrorResponse, streamText } from "@/lib/ai/utils";
 import { DIAGNOSIS_SYSTEM_PROMPT, buildDiagnosisUserMessage } from "@/lib/ai/prompts";
 import { getUserAnalysis } from "@/lib/analysis";
+import { prisma } from "@/lib/prisma";
 
 export async function POST() {
   try {
@@ -13,7 +14,8 @@ export async function POST() {
     const userId = session.user.id;
     if (!(await isAIConfigured(userId))) return NextResponse.json({ message: "请在个人中心填入 API Key 或设置环境变量以启用 AI" }, { status: 503 });
     if (!checkAIRateLimit(userId)) return NextResponse.json({ message: "AI 调用太频繁啦，请稍后再试" }, { status: 429 });
-    const stats = await getUserAnalysis(userId);
+    const diagUser = await prisma.user.findUnique({ where: { id: userId }, select: { targetExamDate: true } });
+    const stats = await getUserAnalysis(userId, diagUser?.targetExamDate);
     const userMessage = buildDiagnosisUserMessage({ overview: stats.overview, knowledgePoints: stats.knowledgePoints });
     const provider = await getAIProvider(userId);
     return streamText(provider.streamCompletion({ systemPrompt: DIAGNOSIS_SYSTEM_PROMPT, userMessage, maxTokens: 1800, temperature: 0.3 }));

--- a/src/app/api/ai/today-plan-diagnosis/route.ts
+++ b/src/app/api/ai/today-plan-diagnosis/route.ts
@@ -45,17 +45,20 @@ export async function POST(request: Request) {
     const requestedDayNumber = normalizeDayNumber(body.dayNumber);
     if (!planId) return NextResponse.json({ message: '缺少计划 ID' }, { status: 400 });
 
-    const plan = await prisma.studyPlan.findFirst({
-      where: { id: planId, userId },
-      select: {
-        title: true,
-        targetExamDate: true,
-        days: {
-          orderBy: { dayNumber: 'asc' },
-          select: { dayNumber: true, date: true, tasks: true, completed: true },
+    const [plan, planUser] = await Promise.all([
+      prisma.studyPlan.findFirst({
+        where: { id: planId, userId },
+        select: {
+          title: true,
+          targetExamDate: true,
+          days: {
+            orderBy: { dayNumber: 'asc' },
+            select: { dayNumber: true, date: true, tasks: true, completed: true },
+          },
         },
-      },
-    });
+      }),
+      prisma.user.findUnique({ where: { id: userId }, select: { targetExamDate: true } }),
+    ]);
     if (!plan) return NextResponse.json({ message: '计划不存在' }, { status: 404 });
 
     const todayKey = getChinaDateKey(new Date());
@@ -78,7 +81,7 @@ export async function POST(request: Request) {
     ]);
     const userMessage = buildTodayPlanDiagnosisUserMessage({
       planTitle: plan.title,
-      targetExamDate: getChinaDateKey(plan.targetExamDate),
+      targetExamDate: getChinaDateKey(planUser?.targetExamDate ?? plan.targetExamDate),
       dayNumber: day.dayNumber,
       date: getChinaDateKey(day.date),
       completed: day.completed,

--- a/src/app/api/analysis/route.ts
+++ b/src/app/api/analysis/route.ts
@@ -1,9 +1,12 @@
 ﻿import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { getUserAnalysis } from "@/lib/analysis";
+import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const session = await auth();
   if (!session?.user?.id) return NextResponse.json({ message: "请先登录" }, { status: 401 });
-  return NextResponse.json(await getUserAnalysis(session.user.id));
+  const userId = session.user.id;
+  const analysisUser = await prisma.user.findUnique({ where: { id: userId }, select: { targetExamDate: true } });
+  return NextResponse.json(await getUserAnalysis(userId, analysisUser?.targetExamDate));
 }

--- a/src/lib/ai/learning-context.ts
+++ b/src/lib/ai/learning-context.ts
@@ -149,8 +149,12 @@ export async function buildLearningKnowledgeBase(userId: string) {
   const todayRange = getTodayRange();
   const todayKey = getChinaDateKey(new Date());
 
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true, targetExamDate: true, createdAt: true },
+  });
+
   const [
-    user,
     analysis,
     activePlan,
     wrongNotes,
@@ -164,11 +168,7 @@ export async function buildLearningKnowledgeBase(userId: string) {
     todayCaseCount,
     todayCaseAnswers,
   ] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: { name: true, targetExamDate: true, createdAt: true },
-    }),
-    getUserAnalysis(userId),
+    getUserAnalysis(userId, user?.targetExamDate),
     prisma.studyPlan.findFirst({
       where: { userId, status: 'ACTIVE' },
       orderBy: { createdAt: 'desc' },

--- a/src/lib/analysis.ts
+++ b/src/lib/analysis.ts
@@ -103,7 +103,7 @@ function toAnalysis(
   };
 }
 
-export async function getUserAnalysis(userId: string) {
+export async function getUserAnalysis(userId: string, targetExamDate?: Date | null) {
   const trendKeys = getRecentDateKeys(RECENT_TREND_DAYS_ANALYSIS);
   const recent7Keys = new Set(trendKeys.slice(-7));
 
@@ -238,7 +238,7 @@ export async function getUserAnalysis(userId: string) {
       : overallMastery >= MEDIUM_MASTERY_THRESHOLD
         ? '中'
         : '低';
-  const exam = getNextExamCountdown();
+  const exam = getNextExamCountdown(new Date(), targetExamDate);
   const totalWrong = wrongRows.reduce((sum, row) => sum + row._count._all, 0);
   const unmasteredCount = await prisma.wrongNote.count({
     where: { userId, markedMastered: false },

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -71,12 +71,15 @@ function daysBetweenChinaKeys(fromKey: string, toKey: string) {
   return Math.round((toMs - fromMs) / 86_400_000);
 }
 
-export function getNextExamCountdown(now = new Date()) {
+export function getNextExamCountdown(now = new Date(), targetDate?: Date | null) {
+  const todayKey = getChinaDateKey(now);
+  if (targetDate) {
+    return { date: targetDate, days: Math.max(0, daysBetweenChinaKeys(todayKey, getChinaDateKey(targetDate))) };
+  }
   const year = Number(new Intl.DateTimeFormat("en-US", { timeZone: "Asia/Shanghai", year: "numeric" }).format(now));
   const candidates = [year, year + 1].flatMap((candidateYear) => [5, 11].map((month) => getThirdSaturday(candidateYear, month)));
   const current = now.getTime();
   const target = candidates.find((date) => date.getTime() >= current) ?? candidates[candidates.length - 1];
-  const todayKey = getChinaDateKey(now);
   const targetKey = getChinaDateKey(target);
   return {
     date: target,


### PR DESCRIPTION
Fixes #28

## Changes

- `src/lib/stats.ts`: Added optional `targetDate` parameter to `getNextExamCountdown`; uses it directly when provided, falls back to default softcao exam schedule
- `src/lib/analysis.ts`: `getUserAnalysis` now accepts and forwards `targetExamDate`
- `src/lib/ai/learning-context.ts`: Fetch user first, then pass `targetExamDate` to `getUserAnalysis` in parallel block
- `src/app/api/ai/today-plan-diagnosis/route.ts`: Fetch user and plan concurrently; prefer `user.targetExamDate` over `plan.targetExamDate`
- `src/app/api/ai/diagnosis/route.ts`, `src/app/api/analysis/route.ts`, `src/app/(main)/analysis/page.tsx`: All fetch and pass `User.targetExamDate`

Generated with [Claude Code](https://claude.ai/code)