### PR TITLE
feat: introduce short TTL cache for learning context

### DIFF
--- a/src/app/api/exam/[id]/submit/route.ts
+++ b/src/app/api/exam/[id]/submit/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { gradeCaseLocal, gradeCaseWithAI } from "@/lib/grade";
+import { invalidateLearning } from "@/lib/ai/context-cache";
 
 type CaseAnswerMap = Record<string, string>;
 
@@ -126,6 +127,8 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
       }
     }
   });
+
+  invalidateLearning(userId);
 
   return NextResponse.json({ totalScore, choiceScore, caseScore });
 }

--- a/src/app/api/plan/[id]/day/[dayNumber]/route.ts
+++ b/src/app/api/plan/[id]/day/[dayNumber]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { invalidateLearningStable } from "@/lib/ai/context-cache";
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string; dayNumber: string }> }) {
   const session = await auth();
@@ -21,5 +22,6 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
       ...(notes !== undefined ? { notes } : {}),
     },
   });
+  invalidateLearningStable(session.user.id);
   return NextResponse.json({ day });
 }

--- a/src/app/api/plan/[id]/route.ts
+++ b/src/app/api/plan/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { isAllowedEnum } from "@/lib/validate";
+import { invalidateLearningStable } from "@/lib/ai/context-cache";
 
 const PLAN_STATUS = ["ACTIVE", "COMPLETED", "ABANDONED"] as const;
 
@@ -25,6 +26,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
   const result = await prisma.studyPlan.updateMany({ where: { id, userId: session.user.id }, data: { status: body.status } });
   if (result.count === 0) return NextResponse.json({ message: "计划不存在" }, { status: 404 });
   const updated = await prisma.studyPlan.findUnique({ where: { id } });
+  invalidateLearningStable(session.user.id);
   return NextResponse.json({ plan: updated });
 }
 
@@ -34,5 +36,6 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
   const { id } = await params;
   const result = await prisma.studyPlan.deleteMany({ where: { id, userId: session.user.id } });
   if (result.count === 0) return NextResponse.json({ message: "计划不存在" }, { status: 404 });
+  invalidateLearningStable(session.user.id);
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/plan/generate/route.ts
+++ b/src/app/api/plan/generate/route.ts
@@ -8,6 +8,7 @@ import { STUDY_PLAN_SYSTEM_PROMPT, buildStudyPlanUserMessage } from "@/lib/ai/pr
 import { getUserAnalysis } from "@/lib/analysis";
 import { prisma } from "@/lib/prisma";
 import { parseFiniteDate } from "@/lib/validate";
+import { invalidateLearningStable } from "@/lib/ai/context-cache";
 
 const MAX_PLAN_DAYS = 60;
 
@@ -99,6 +100,7 @@ export async function POST(request: Request) {
         },
       }),
     );
+    invalidateLearningStable(userId);
     return NextResponse.json({ planId: plan.id, content: overviewContent });
   } catch (error) {
     return createAIErrorResponse(error);

--- a/src/app/api/practice/answer/route.ts
+++ b/src/app/api/practice/answer/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { invalidateLearning } from "@/lib/ai/context-cache";
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -61,6 +62,8 @@ export async function POST(request: Request) {
     }
     return created;
   });
+
+  invalidateLearning(userId);
 
   return NextResponse.json({
     answerId: answer.id,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { parseFiniteDate } from '@/lib/validate';
+import { invalidateLearningAnalysis } from '@/lib/ai/context-cache';
 
 export async function GET() {
   const session = await auth();
@@ -49,5 +50,8 @@ export async function PATCH(request: Request) {
     data,
     select: { id: true, name: true, email: true, targetExamDate: true, createdAt: true },
   });
+  if ('targetExamDate' in data) {
+    invalidateLearningAnalysis(session.user.id);
+  }
   return NextResponse.json({ user, message });
 }

--- a/src/app/api/wrong-notes/[id]/route.ts
+++ b/src/app/api/wrong-notes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { invalidateLearning } from "@/lib/ai/context-cache";
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await auth();
@@ -20,6 +21,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
       ...(trimmedNote !== undefined ? { note: trimmedNote } : {}),
     },
   });
+  invalidateLearning(session.user.id);
   return NextResponse.json({ item: updated, message: "错题状态已更新" });
 }
 
@@ -29,5 +31,6 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
   const { id } = await params;
   const result = await prisma.wrongNote.deleteMany({ where: { id, userId: session.user.id } });
   if (result.count === 0) return NextResponse.json({ message: "错题不存在" }, { status: 404 });
+  invalidateLearning(session.user.id);
   return NextResponse.json({ message: "已从错题本移除" });
 }

--- a/src/lib/ai/context-cache.ts
+++ b/src/lib/ai/context-cache.ts
@@ -1,0 +1,57 @@
+const ANALYSIS_TTL_MS = 60_000;
+const STABLE_TTL_MS = 60_000;
+const CLEANUP_INTERVAL_MS = 5 * 60_000;
+
+type CacheEntry<T> = { value: T; expiresAt: number };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const analysisCache = new Map<string, CacheEntry<any>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stableCache = new Map<string, CacheEntry<any>>();
+let lastCleanup = 0;
+
+function cleanup(now: number) {
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+  for (const [key, entry] of analysisCache) {
+    if (entry.expiresAt <= now) analysisCache.delete(key);
+  }
+  for (const [key, entry] of stableCache) {
+    if (entry.expiresAt <= now) stableCache.delete(key);
+  }
+}
+
+export async function getOrSetAnalysis<T>(userId: string, compute: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  cleanup(now);
+  const key = `analysis:${userId}`;
+  const cached = analysisCache.get(key) as CacheEntry<T> | undefined;
+  if (cached && cached.expiresAt > now) return cached.value;
+  const value = await compute();
+  analysisCache.set(key, { value, expiresAt: now + ANALYSIS_TTL_MS });
+  return value;
+}
+
+export async function getOrSetStable<T>(userId: string, compute: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  cleanup(now);
+  const key = `stable:${userId}`;
+  const cached = stableCache.get(key) as CacheEntry<T> | undefined;
+  if (cached && cached.expiresAt > now) return cached.value;
+  const value = await compute();
+  stableCache.set(key, { value, expiresAt: now + STABLE_TTL_MS });
+  return value;
+}
+
+export function invalidateLearningAnalysis(userId: string) {
+  analysisCache.delete(`analysis:${userId}`);
+}
+
+export function invalidateLearningStable(userId: string) {
+  stableCache.delete(`stable:${userId}`);
+}
+
+export function invalidateLearning(userId: string) {
+  invalidateLearningAnalysis(userId);
+  invalidateLearningStable(userId);
+}

--- a/src/lib/ai/context-cache.ts
+++ b/src/lib/ai/context-cache.ts
@@ -4,10 +4,10 @@ const CLEANUP_INTERVAL_MS = 5 * 60_000;
 
 type CacheEntry<T> = { value: T; expiresAt: number };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const analysisCache = new Map<string, CacheEntry<any>>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const stableCache = new Map<string, CacheEntry<any>>();
+const analysisCache = new Map<string, CacheEntry<unknown>>();
+const stableCache = new Map<string, CacheEntry<unknown>>();
+const inflightAnalysis = new Map<string, Promise<unknown>>();
+const inflightStable = new Map<string, Promise<unknown>>();
 let lastCleanup = 0;
 
 function cleanup(now: number) {
@@ -27,9 +27,21 @@ export async function getOrSetAnalysis<T>(userId: string, compute: () => Promise
   const key = `analysis:${userId}`;
   const cached = analysisCache.get(key) as CacheEntry<T> | undefined;
   if (cached && cached.expiresAt > now) return cached.value;
-  const value = await compute();
-  analysisCache.set(key, { value, expiresAt: now + ANALYSIS_TTL_MS });
-  return value;
+  const existing = inflightAnalysis.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const promise = compute().then(
+    (value) => {
+      analysisCache.set(key, { value, expiresAt: Date.now() + ANALYSIS_TTL_MS });
+      inflightAnalysis.delete(key);
+      return value;
+    },
+    (err: unknown) => {
+      inflightAnalysis.delete(key);
+      throw err;
+    },
+  );
+  inflightAnalysis.set(key, promise);
+  return promise;
 }
 
 export async function getOrSetStable<T>(userId: string, compute: () => Promise<T>): Promise<T> {
@@ -38,9 +50,21 @@ export async function getOrSetStable<T>(userId: string, compute: () => Promise<T
   const key = `stable:${userId}`;
   const cached = stableCache.get(key) as CacheEntry<T> | undefined;
   if (cached && cached.expiresAt > now) return cached.value;
-  const value = await compute();
-  stableCache.set(key, { value, expiresAt: now + STABLE_TTL_MS });
-  return value;
+  const existing = inflightStable.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const promise = compute().then(
+    (value) => {
+      stableCache.set(key, { value, expiresAt: Date.now() + STABLE_TTL_MS });
+      inflightStable.delete(key);
+      return value;
+    },
+    (err: unknown) => {
+      inflightStable.delete(key);
+      throw err;
+    },
+  );
+  inflightStable.set(key, promise);
+  return promise;
 }
 
 export function invalidateLearningAnalysis(userId: string) {

--- a/src/lib/ai/learning-context.ts
+++ b/src/lib/ai/learning-context.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { getUserAnalysis } from '@/lib/analysis';
 import { getChinaDateKey, getTodayRange } from '@/lib/stats';
+import { getOrSetAnalysis, getOrSetStable } from '@/lib/ai/context-cache';
 
 const MAX_CONTEXT_CHARS = 18_000;
 const MAX_TODAY_CHOICE_DETAILS = 80;
@@ -145,30 +146,8 @@ function formatWrongChoiceDetail(answer: ChoiceAnswerDetail, index: number) {
 题库解析：${compactText(answer.question.explanation, MAX_TEXT_CHARS.explanation)}`;
 }
 
-export async function buildLearningKnowledgeBase(userId: string) {
-  const todayRange = getTodayRange();
-  const todayKey = getChinaDateKey(new Date());
-
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { name: true, targetExamDate: true, createdAt: true },
-  });
-
-  const [
-    analysis,
-    activePlan,
-    wrongNotes,
-    recentExams,
-    todayPracticeChoiceCount,
-    todayPracticeWrongCount,
-    todayExamChoiceCount,
-    todayExamWrongCount,
-    todayPracticeAnswers,
-    todayExamAnswers,
-    todayCaseCount,
-    todayCaseAnswers,
-  ] = await Promise.all([
-    getUserAnalysis(userId, user?.targetExamDate),
+async function fetchStableData(userId: string) {
+  const [activePlan, wrongNotes, recentExams] = await Promise.all([
     prisma.studyPlan.findFirst({
       where: { userId, status: 'ACTIVE' },
       orderBy: { createdAt: 'desc' },
@@ -231,6 +210,39 @@ export async function buildLearningKnowledgeBase(userId: string) {
         exam: { select: { title: true, totalScore: true } },
       },
     }),
+  ]);
+
+  const wrongQuestionIds = wrongNotes.map((note) => note.questionId);
+  const examWrongAnswers = wrongQuestionIds.length
+    ? await prisma.examAnswer.findMany({
+        where: {
+          questionId: { in: wrongQuestionIds },
+          selectedOptionId: { not: null },
+          isCorrect: false,
+          examAttempt: { userId, status: 'COMPLETED' },
+        },
+        select: {
+          questionId: true,
+          selectedOption: { select: { id: true, label: true, content: true } },
+          examAttempt: { select: { finishedAt: true, startedAt: true } },
+        },
+      })
+    : [];
+
+  return { activePlan, wrongNotes, recentExams, examWrongAnswers };
+}
+
+async function fetchTodayData(userId: string, todayRange: { start: Date; end: Date }) {
+  const [
+    todayPracticeChoiceCount,
+    todayPracticeWrongCount,
+    todayExamChoiceCount,
+    todayExamWrongCount,
+    todayPracticeAnswers,
+    todayExamAnswers,
+    todayCaseCount,
+    todayCaseAnswers,
+  ] = await Promise.all([
     prisma.userAnswer.count({
       where: { userId, createdAt: { gte: todayRange.start, lt: todayRange.end } },
     }),
@@ -359,22 +371,44 @@ export async function buildLearningKnowledgeBase(userId: string) {
     }),
   ]);
 
-  const wrongQuestionIds = wrongNotes.map((note) => note.questionId);
-  const examWrongAnswers = wrongQuestionIds.length
-    ? await prisma.examAnswer.findMany({
-        where: {
-          questionId: { in: wrongQuestionIds },
-          selectedOptionId: { not: null },
-          isCorrect: false,
-          examAttempt: { userId, status: 'COMPLETED' },
-        },
-        select: {
-          questionId: true,
-          selectedOption: { select: { id: true, label: true, content: true } },
-          examAttempt: { select: { finishedAt: true, startedAt: true } },
-        },
-      })
-    : [];
+  return {
+    todayPracticeChoiceCount,
+    todayPracticeWrongCount,
+    todayExamChoiceCount,
+    todayExamWrongCount,
+    todayPracticeAnswers,
+    todayExamAnswers,
+    todayCaseCount,
+    todayCaseAnswers,
+  };
+}
+
+export async function buildLearningKnowledgeBase(userId: string) {
+  const todayRange = getTodayRange();
+  const todayKey = getChinaDateKey(new Date());
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true, targetExamDate: true, createdAt: true },
+  });
+
+  const [analysis, stableData, todayData] = await Promise.all([
+    getOrSetAnalysis(userId, () => getUserAnalysis(userId, user?.targetExamDate)),
+    getOrSetStable(userId, () => fetchStableData(userId)),
+    fetchTodayData(userId, todayRange),
+  ]);
+
+  const { activePlan, wrongNotes, recentExams, examWrongAnswers } = stableData;
+  const {
+    todayPracticeChoiceCount,
+    todayPracticeWrongCount,
+    todayExamChoiceCount,
+    todayExamWrongCount,
+    todayPracticeAnswers,
+    todayExamAnswers,
+    todayCaseCount,
+    todayCaseAnswers,
+  } = todayData;
 
   const latestExamWrongByQuestion = new Map<string, (typeof examWrongAnswers)[number]>();
   for (const answer of examWrongAnswers) {
@@ -490,7 +524,7 @@ ${todayTasks.map((task, index) => `${index + 1}. ${task}`).join('\n') || '今日
 
   const context = `## 学生当前学习情况知识库
 使用规则：
-- 以下数据是该学生的真实学习上下文。回答“今天错题/今天做题/错题本/学习计划/薄弱点”时，优先使用对应明细，不要要求学生再上传截图或题干。
+- 以下数据是该学生的真实学习上下文。回答"今天错题/今天做题/错题本/学习计划/薄弱点"时，优先使用对应明细，不要要求学生再上传截图或题干。
 - 如果明细里已经列出题干、学生选择、正确答案和解析，可以直接据此复盘。
 - 不要编造没有出现在数据中的成绩、题目、选项、计划或日期。若某类数据为空或被截断，要明确说明。
 

--- a/src/test/context-cache.test.ts
+++ b/src/test/context-cache.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getOrSetAnalysis,
+  getOrSetStable,
+  invalidateLearning,
+  invalidateLearningAnalysis,
+  invalidateLearningStable,
+} from '@/lib/ai/context-cache';
+
+const USER = 'cache-test-user';
+
+afterEach(() => {
+  invalidateLearning(USER);
+});
+
+describe('getOrSetAnalysis', () => {
+  it('returns cached value without re-executing compute on hit', async () => {
+    const compute = vi.fn().mockResolvedValue('result');
+    const r1 = await getOrSetAnalysis(USER, compute);
+    const r2 = await getOrSetAnalysis(USER, compute);
+    expect(r1).toBe('result');
+    expect(r2).toBe('result');
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-executes compute after invalidateLearningAnalysis', async () => {
+    const compute = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+    await getOrSetAnalysis(USER, compute);
+    invalidateLearningAnalysis(USER);
+    const r2 = await getOrSetAnalysis(USER, compute);
+    expect(r2).toBe('v2');
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it('concurrent misses coalesce to a single compute call', async () => {
+    let resolve!: (v: string) => void;
+    const pending = new Promise<string>((res) => {
+      resolve = res;
+    });
+    const compute = vi.fn().mockReturnValue(pending);
+
+    const p1 = getOrSetAnalysis(USER, compute);
+    const p2 = getOrSetAnalysis(USER, compute);
+    const p3 = getOrSetAnalysis(USER, compute);
+
+    resolve('shared');
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toBe('shared');
+    expect(r2).toBe('shared');
+    expect(r3).toBe('shared');
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears inflight on compute failure so next request retries', async () => {
+    const err = new Error('oops');
+    const compute = vi.fn().mockRejectedValueOnce(err).mockResolvedValueOnce('recovered');
+
+    await expect(getOrSetAnalysis(USER, compute)).rejects.toThrow('oops');
+    const result = await getOrSetAnalysis(USER, compute);
+    expect(result).toBe('recovered');
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getOrSetStable', () => {
+  it('returns cached value without re-executing compute on hit', async () => {
+    const compute = vi.fn().mockResolvedValue('stable-result');
+    await getOrSetStable(USER, compute);
+    await getOrSetStable(USER, compute);
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-executes compute after invalidateLearningStable', async () => {
+    const compute = vi.fn().mockResolvedValueOnce('s1').mockResolvedValueOnce('s2');
+    await getOrSetStable(USER, compute);
+    invalidateLearningStable(USER);
+    const r = await getOrSetStable(USER, compute);
+    expect(r).toBe('s2');
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it('concurrent misses coalesce to a single compute call', async () => {
+    let resolve!: (v: string) => void;
+    const pending = new Promise<string>((res) => {
+      resolve = res;
+    });
+    const compute = vi.fn().mockReturnValue(pending);
+
+    const p1 = getOrSetStable(USER, compute);
+    const p2 = getOrSetStable(USER, compute);
+
+    resolve('coalesced');
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe('coalesced');
+    expect(r2).toBe('coalesced');
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('invalidateLearning', () => {
+  it('clears both analysis and stable caches', async () => {
+    const aCompute = vi.fn().mockResolvedValue('a');
+    const sCompute = vi.fn().mockResolvedValue('s');
+    await getOrSetAnalysis(USER, aCompute);
+    await getOrSetStable(USER, sCompute);
+
+    invalidateLearning(USER);
+
+    await getOrSetAnalysis(USER, aCompute);
+    await getOrSetStable(USER, sCompute);
+    expect(aCompute).toHaveBeenCalledTimes(2);
+    expect(sCompute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/test/learning-context.test.ts
+++ b/src/test/learning-context.test.ts
@@ -1,17 +1,21 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { buildLearningKnowledgeBase } from '@/lib/ai/learning-context';
+import { invalidateLearning } from '@/lib/ai/context-cache';
 import { prisma } from '@/lib/prisma';
 import { createTestUser, resetUserData } from '@/test/helpers';
 
+const TEST_USER_ID = 'learning-context-user';
+
 describe('buildLearningKnowledgeBase', () => {
   beforeEach(async () => {
+    invalidateLearning(TEST_USER_ID);
     await resetUserData();
   });
 
   it('includes today wrong choice details with selected and correct answers', async () => {
     const user = await createTestUser({
-      id: 'learning-context-user',
+      id: TEST_USER_ID,
       email: 'learning-context@example.com',
     });
     const wrongOption = await prisma.questionOption.findUniqueOrThrow({


### PR DESCRIPTION
Implements # 30.

Adds a two-tier in-memory TTL cache to `buildLearningKnowledgeBase` to reduce repeated DB queries on frequent AI calls:

- `analysis` cache (60s TTL): wraps `getUserAnalysis()`, the heaviest aggregation query
- `stable` cache (60s TTL): wraps plan, wrongNotes, recentExams
- Today's answers and case data remain live (no cache) to avoid stale prompt injection risk
- Active invalidation on all relevant mutation routes

Generated with [Claude Code](https://claude.ai/code)