### PR TITLE
feat: 完善 AI 视觉模型能力检测

### DIFF
--- a/src/app/api/ai/explain/route.ts
+++ b/src/app/api/ai/explain/route.ts
@@ -30,9 +30,11 @@ export async function POST(request: Request) {
 
     if (imageUrls.length > 0 && !provider.supportsVision()) {
       const { model } = provider.getInfo();
-      return NextResponse.json({
-        message: `当前配置的模型（${model}）不支持视觉输入，无法分析题目中的图片。如需对含图题进行 AI 深度讲解，请在个人中心切换支持视觉的模型（如 claude-sonnet-4-5、gpt-4o、gemini-2.5-flash 等）。`,
-      }, { status: 422 });
+      const visionTested = config.visionSupport !== null && config.visionSupport !== undefined;
+      const message = visionTested
+        ? `当前配置的模型（${model}）不支持视觉输入，无法分析题目中的图片。如需对含图题进行 AI 深度讲解，请在个人中心切换支持视觉的模型（如 claude-sonnet-4-6、gpt-4o、gemini-2.5-flash 等）。`
+        : `当前模型（${model}）的视觉能力尚未检测。请前往个人中心点击「测试视觉能力」，确认模型支持视觉输入后再进行含图题讲解。`;
+      return NextResponse.json({ message }, { status: 422 });
     }
 
     return streamText(provider.streamCompletion({

--- a/src/app/api/profile/ai-settings/route.ts
+++ b/src/app/api/profile/ai-settings/route.ts
@@ -46,6 +46,7 @@ export async function GET() {
     baseUrl: settings?.baseUrl ?? null,
     apiKeyMasked: maskApiKey(settings?.apiKey),
     hasApiKey: Boolean(settings?.apiKey),
+    visionSupport: settings?.visionSupport ?? null,
     imageProvider: settings?.imageProvider ?? null,
     imageModel: settings?.imageModel ?? null,
     imageBaseUrl: settings?.imageBaseUrl ?? null,
@@ -85,6 +86,10 @@ export async function PUT(request: Request) {
   if (provider === 'custom' && !baseUrl) {
     return NextResponse.json({ message: 'custom 供应商必须填写 Base URL' }, { status: 400 });
   }
+
+  const providerChanged = provider !== (existing?.provider ?? '');
+  const modelChanged = model !== (existing?.model ?? '');
+  const nextVisionSupport = providerChanged || modelChanged ? null : (existing?.visionSupport ?? null);
 
   const nextApiKey = clearApiKey
     ? null
@@ -143,6 +148,7 @@ export async function PUT(request: Request) {
       model: model || null,
       baseUrl: baseUrl || null,
       apiKey: nextApiKey,
+      visionSupport: nextVisionSupport,
       imageProvider: imageProvider || null,
       imageModel: imageModel || null,
       imageBaseUrl: imageBaseUrl || null,
@@ -161,6 +167,7 @@ export async function PUT(request: Request) {
       model: model || null,
       baseUrl: baseUrl || null,
       apiKey: nextApiKey,
+      visionSupport: nextVisionSupport,
       imageProvider: imageProvider || null,
       imageModel: imageModel || null,
       imageBaseUrl: imageBaseUrl || null,

--- a/src/app/api/profile/ai-settings/vision-test/route.ts
+++ b/src/app/api/profile/ai-settings/vision-test/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { aiSettingsError, resolveAIConfigFromRequest, testVisionCapability } from "@/lib/ai/settings";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ message: "请先登录" }, { status: 401 });
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const config = await resolveAIConfigFromRequest(session.user.id, body);
+    const result = await testVisionCapability(config);
+
+    const existing = await prisma.userAISettings.findUnique({ where: { userId: session.user.id } });
+    if (existing) {
+      await prisma.userAISettings.update({
+        where: { userId: session.user.id },
+        data: { visionSupport: result.supportsVision },
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      supportsVision: result.supportsVision,
+      latencyMs: result.latencyMs,
+    });
+  } catch (error) {
+    return NextResponse.json({ message: aiSettingsError(error) }, { status: 400 });
+  }
+}

--- a/src/components/ai-settings-card.tsx
+++ b/src/components/ai-settings-card.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import Image from 'next/image';
-import { CheckCircle2, ImageIcon, Loader2, RefreshCw, Save, Trash2, Zap } from 'lucide-react';
+import { CheckCircle2, Eye, ImageIcon, Loader2, RefreshCw, Save, Trash2, Zap } from 'lucide-react';
 
 import { useAIStatus } from '@/components/ai-status-context';
 import { Button } from '@/components/ui/button';
@@ -23,6 +23,7 @@ type Settings = {
   baseUrl: string | null;
   apiKeyMasked: string | null;
   hasApiKey: boolean;
+  visionSupport: boolean | null;
   imageProvider: string | null;
   imageModel: string | null;
   imageBaseUrl: string | null;
@@ -50,6 +51,7 @@ const DEFAULT_SETTINGS: Settings = {
   baseUrl: null,
   apiKeyMasked: null,
   hasApiKey: false,
+  visionSupport: null,
   imageProvider: null,
   imageModel: null,
   imageBaseUrl: null,
@@ -98,8 +100,9 @@ export function AISettingsCard() {
   const [loadingImageModels, setLoadingImageModels] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testingImage, setTestingImage] = useState(false);
+  const [testingVision, setTestingVision] = useState(false);
 
-  const busy = loading || saving || loadingModels || loadingImageModels || testing || testingImage;
+  const busy = loading || saving || loadingModels || loadingImageModels || testing || testingImage || testingVision;
   const selectedImageStyle =
     AI_IMAGE_STYLE_OPTIONS.find(
       (option) => option.value === (settings.imageStyle || 'clean_education_card')
@@ -165,6 +168,7 @@ export function AISettingsCard() {
     setModels([]);
     setTestResult(null);
   }, [settings.provider, settings.baseUrl]);
+
 
   useEffect(() => {
     setImageModels([]);
@@ -315,6 +319,38 @@ export function AISettingsCard() {
     }
   }
 
+  async function testVisionCapability() {
+    setTestingVision(true);
+    setMessage(null);
+    try {
+      const response = await fetch('/api/profile/ai-settings/vision-test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestPayload),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage({
+          kind: 'error',
+          text: (data as { message?: string }).message || '视觉能力测试失败',
+        });
+        return;
+      }
+      const result = data as { supportsVision: boolean; latencyMs: number };
+      setSettings((prev) => ({ ...prev, visionSupport: result.supportsVision }));
+      setMessage({
+        kind: result.supportsVision ? 'ok' : 'error',
+        text: result.supportsVision
+          ? `视觉能力测试通过（${result.latencyMs}ms），该模型支持图像输入`
+          : `视觉能力测试未通过（${result.latencyMs}ms），该模型不支持图像输入`,
+      });
+    } catch {
+      setMessage({ kind: 'error', text: '视觉能力测试失败，请检查网络、API Key 或模型名称' });
+    } finally {
+      setTestingVision(false);
+    }
+  }
+
   async function clearConfig() {
     if (!confirm('确认清空个人 AI 配置并回落到服务器环境变量？')) return;
     setSaving(true);
@@ -395,9 +431,23 @@ export function AISettingsCard() {
           </p>
         </div>
       </div>
-      <div className="mt-3 rounded-3xl bg-softRose p-4">
-        <p className="font-black text-muted">当前 Endpoint</p>
-        <p className="mt-2 break-all font-bold text-navy">{status.endpoint ?? '未配置'}</p>
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-3xl bg-softRose p-4">
+          <p className="font-black text-muted">当前 Endpoint</p>
+          <p className="mt-2 break-all font-bold text-navy">{status.endpoint ?? '未配置'}</p>
+        </div>
+        <div className="rounded-3xl bg-white/70 p-4">
+          <p className="font-black text-muted">视觉能力</p>
+          <div className="mt-2 flex items-center gap-2">
+            {settings.visionSupport === true ? (
+              <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-bold text-green-800">支持视觉</span>
+            ) : settings.visionSupport === false ? (
+              <span className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-bold text-red-700">不支持视觉</span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-bold text-gray-600">未检测</span>
+            )}
+          </div>
+        </div>
       </div>
 
       <form onSubmit={onSubmit} className="mt-6 space-y-4">
@@ -415,7 +465,7 @@ export function AISettingsCard() {
               options={PROVIDERS}
               disabled={busy}
               onChange={(provider) =>
-                setSettings((prev) => ({ ...prev, provider: provider || null }))
+                setSettings((prev) => ({ ...prev, provider: provider || null, visionSupport: null }))
               }
             />
           </div>
@@ -427,7 +477,7 @@ export function AISettingsCard() {
                 list="ai-model-options"
                 value={settings.model ?? ''}
                 onChange={(event) =>
-                  setSettings((prev) => ({ ...prev, model: event.target.value }))
+                  setSettings((prev) => ({ ...prev, model: event.target.value, visionSupport: null }))
                 }
                 placeholder="留空使用默认值，例如 gpt-4o-mini"
                 disabled={busy}
@@ -748,6 +798,14 @@ export function AISettingsCard() {
           <Button type="button" variant="secondary" onClick={testConnection} disabled={busy}>
             {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Zap className="h-4 w-4" />}
             测试文本模型
+          </Button>
+          <Button type="button" variant="secondary" onClick={testVisionCapability} disabled={busy}>
+            {testingVision ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+            测试视觉能力
           </Button>
           <Button type="button" variant="secondary" onClick={testImageConnection} disabled={busy}>
             {testingImage ? (

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -61,6 +61,7 @@ export async function resolveAIConfig(userId?: string | null): Promise<AIConfig 
           apiKey: settings?.apiKey ?? undefined,
           model: settings?.model ?? undefined,
           baseUrl: settings?.baseUrl ?? undefined,
+          visionSupport: settings?.visionSupport ?? null,
         };
       }
     }

--- a/src/lib/ai/providers/claude.ts
+++ b/src/lib/ai/providers/claude.ts
@@ -5,6 +5,12 @@ import { getSanitizedEndpoint } from "@/lib/ai/utils";
 const defaultBaseUrl = "https://api.anthropic.com";
 const defaultModel = "claude-sonnet-4-5-20250929";
 
+function parseDataUrl(url: string): { mediaType: "image/jpeg" | "image/png" | "image/gif" | "image/webp"; data: string } | null {
+  const match = url.match(/^data:(image\/(?:jpeg|png|gif|webp));base64,(.+)$/);
+  if (!match) return null;
+  return { mediaType: match[1] as "image/jpeg" | "image/png" | "image/gif" | "image/webp", data: match[2] };
+}
+
 function buildMessages(params: CompletionParams): Anthropic.MessageParam[] {
   if (params.messages?.length) {
     return params.messages.map((message) => ({ role: message.role, content: message.content }));
@@ -12,10 +18,19 @@ function buildMessages(params: CompletionParams): Anthropic.MessageParam[] {
   if (!params.imageUrls?.length) {
     return [{ role: "user", content: params.userMessage }];
   }
-  const content: Anthropic.ContentBlockParam[] = params.imageUrls.map((url) => ({
-    type: "image" as const,
-    source: { type: "url" as const, url },
-  }));
+  const content: Anthropic.ContentBlockParam[] = params.imageUrls.map((url) => {
+    const parsed = parseDataUrl(url);
+    if (parsed) {
+      return {
+        type: "image" as const,
+        source: { type: "base64" as const, media_type: parsed.mediaType, data: parsed.data },
+      };
+    }
+    return {
+      type: "image" as const,
+      source: { type: "url" as const, url },
+    };
+  });
   content.push({ type: "text", text: params.userMessage });
   return [{ role: "user", content }];
 }

--- a/src/lib/ai/providers/custom.ts
+++ b/src/lib/ai/providers/custom.ts
@@ -51,7 +51,7 @@ export function createCustomProvider(config: AIConfig): AIProvider {
 
   return {
     name: "Custom",
-    supportsVision: () => true,
+    supportsVision: () => config.visionSupport ?? true,
     getInfo() {
       if (!baseUrl) throw new Error("使用 custom 供应商时必须配置 Base URL");
       return {

--- a/src/lib/ai/providers/gemini.ts
+++ b/src/lib/ai/providers/gemini.ts
@@ -5,6 +5,12 @@ import { fetchImageAsBase64, getSanitizedEndpoint } from "@/lib/ai/utils";
 const defaultModel = "gemini-2.5-flash";
 const defaultBaseUrl = "https://generativelanguage.googleapis.com";
 
+function parseDataUrl(url: string): { mimeType: string; base64: string } | null {
+  const match = url.match(/^data:(image\/[a-z+]+);base64,(.+)$/);
+  if (!match) return null;
+  return { mimeType: match[1], base64: match[2] };
+}
+
 async function buildContents(params: CompletionParams) {
   if (params.messages?.length) {
     return params.messages.map((message) => ({
@@ -16,8 +22,13 @@ async function buildContents(params: CompletionParams) {
 
   const parts: Array<{ text?: string; inlineData?: { mimeType: string; data: string } }> = [];
   for (const url of params.imageUrls) {
-    const result = await fetchImageAsBase64(url);
-    if (result) parts.push({ inlineData: { mimeType: result.mimeType, data: result.base64 } });
+    const parsed = parseDataUrl(url);
+    if (parsed) {
+      parts.push({ inlineData: { mimeType: parsed.mimeType, data: parsed.base64 } });
+    } else {
+      const result = await fetchImageAsBase64(url);
+      if (result) parts.push({ inlineData: { mimeType: result.mimeType, data: result.base64 } });
+    }
   }
   parts.push({ text: params.userMessage });
   return [{ role: "user", parts }];

--- a/src/lib/ai/providers/openai.ts
+++ b/src/lib/ai/providers/openai.ts
@@ -12,7 +12,10 @@ function isVisionCapableModel(model: string): boolean {
   if (m.includes("gpt-4-turbo")) return true;
   if (m.includes("gpt-4-vision")) return true;
   if (m.includes("gpt-4.5")) return true;
+  if (m.includes("gpt-4.1")) return true;
+  if (/^gpt-5/.test(m)) return true;
   if (/\bo[134][-\s]/.test(m) || m === "o1" || m === "o3" || m === "o4") return true;
+  if (m.includes("o4-mini")) return true;
   return false;
 }
 
@@ -52,7 +55,7 @@ export function createOpenAIProvider(config: AIConfig): AIProvider {
 
   return {
     name: "OpenAI",
-    supportsVision: () => isVisionCapableModel(model),
+    supportsVision: () => config.visionSupport ?? isVisionCapableModel(model),
     getInfo() {
       return {
         name: "OpenAI",

--- a/src/lib/ai/settings.ts
+++ b/src/lib/ai/settings.ts
@@ -55,11 +55,16 @@ export async function resolveAIConfigFromRequest(userId: string, body: unknown):
     throw new Error("请先填写或保存 API Key");
   }
 
+  const visionSupport = "visionSupport" in data
+    ? (data.visionSupport === true || data.visionSupport === false ? data.visionSupport : null)
+    : null;
+
   return {
     provider: requestedProvider,
     apiKey: apiKey ?? undefined,
     model,
     baseUrl,
+    visionSupport,
   };
 }
 
@@ -91,6 +96,31 @@ export async function testAIConfig(config: AIConfig) {
     latencyMs: Date.now() - startedAt,
     output: content.trim().slice(0, 120),
   };
+}
+
+// Minimal 1×1 transparent PNG encoded as a data URL for vision smoke tests.
+const VISION_TEST_IMAGE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+export async function testVisionCapability(config: AIConfig): Promise<{ supportsVision: boolean; latencyMs: number }> {
+  const startedAt = Date.now();
+  const provider = buildAIProvider({
+    ...config,
+    model: config.model || DEFAULT_MODELS[config.provider],
+    visionSupport: null,
+  });
+  try {
+    await provider.createCompletion({
+      systemPrompt: "You are a vision checker. If you can see images, reply with exactly: OK",
+      userMessage: "Reply with OK only.",
+      imageUrls: [VISION_TEST_IMAGE],
+      maxTokens: 12,
+      temperature: 0,
+    });
+    return { supportsVision: true, latencyMs: Date.now() - startedAt };
+  } catch {
+    return { supportsVision: false, latencyMs: Date.now() - startedAt };
+  }
 }
 
 async function listOpenAICompatibleModels(config: AIConfig, fallbackBaseUrl: string | undefined) {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -25,6 +25,7 @@ export interface AIConfig {
   apiKey?: string;
   model?: string;
   baseUrl?: string;
+  visionSupport?: boolean | null;
 }
 
 export interface AIProvider {

--- a/src/lib/ai/wrong-note-explanation.ts
+++ b/src/lib/ai/wrong-note-explanation.ts
@@ -130,12 +130,11 @@ export async function prepareAndRunWrongNoteExplanation(params: {
 
   if (imageUrls.length > 0 && !provider.supportsVision()) {
     const { model } = provider.getInfo();
-    throw Object.assign(
-      new Error(
-        `当前配置的模型（${model}）不支持视觉输入，无法分析题目中的图片。如需对含图题进行 AI 深度讲解，请在个人中心切换支持视觉的模型（如 claude-sonnet-4-5、gpt-4o、gemini-2.5-flash 等）。`
-      ),
-      { status: 422 }
-    );
+    const visionTested = config.visionSupport !== null && config.visionSupport !== undefined;
+    const errorMessage = visionTested
+      ? `当前配置的模型（${model}）不支持视觉输入，无法分析题目中的图片。如需对含图题进行 AI 深度讲解，请在个人中心切换支持视觉的模型（如 claude-sonnet-4-6、gpt-4o、gemini-2.5-flash 等）。`
+      : `当前模型（${model}）的视觉能力尚未检测。请前往个人中心点击「测试视觉能力」，确认模型支持视觉输入后再进行含图题讲解。`;
+    throw Object.assign(new Error(errorMessage), { status: 422 });
   }
 
   const generation = await prisma.aIExplanationGeneration.create({

--- a/src/prisma/migrations/20260502120000_add_vision_support/migration.sql
+++ b/src/prisma/migrations/20260502120000_add_vision_support/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserAISettings" ADD COLUMN "visionSupport" BOOLEAN;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -85,11 +85,12 @@ model User {
 }
 
 model UserAISettings {
-  userId                  String   @id
+  userId                  String    @id
   provider                String?
   model                   String?
   apiKey                  String?
   baseUrl                 String?
+  visionSupport           Boolean?
   imageProvider           String?
   imageModel              String?
   imageApiKey             String?
@@ -101,8 +102,8 @@ model UserAISettings {
   imageRateLimitPerMinute Int?
   imageRateLimitHourly    Int?
   imageRateLimitDaily     Int?
-  updatedAt               DateTime @updatedAt
-  user                    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  updatedAt               DateTime  @updatedAt
+  user                    User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model PasswordResetToken {


### PR DESCRIPTION
## 变更说明

实现 issue #35 描述的视觉能力检测完善方案：

- 扩展 OpenAI 模型字符串匹配（gpt-4.1, o4-mini, gpt-5.x 系列）
- 新增 visionSupport 字段到 AIConfig 及 DB
- 新增视觉 smoke test API 端点
- 个人中心展示视觉能力状态及检测按钮
- AI 深度讲解区分「未检测」和「明确不支持」两种提示

Closes #35

Generated with [Claude Code](https://claude.ai/code)