### PR TITLE
test: 补充关键业务路径集成测试（issue #31）

### DIFF
--- a/src/test/api-exam.test.ts
+++ b/src/test/api-exam.test.ts
@@ -1,0 +1,462 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import { createTestExam, createTestUser, resetUserData, sessionFor } from '@/test/helpers';
+
+async function loadGenerateRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/exam/generate/route');
+}
+
+async function loadStartRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/exam/[id]/start/route');
+}
+
+async function loadAnswerRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/exam/[id]/answer/route');
+}
+
+async function loadSubmitRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/exam/[id]/submit/route');
+}
+
+async function loadResultRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/exam/[id]/result/route');
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth');
+});
+
+describe('POST /api/exam/generate', () => {
+  beforeEach(resetUserData);
+
+  it('creates an AM mock exam with seeded choice questions', async () => {
+    const user = await createTestUser({ id: 'exam-gen-u1', email: 'exam-gen@example.com' });
+    const appHandler = await loadGenerateRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ session: 'AM' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.exam).toMatchObject({ session: 'AM', type: 'MOCK' });
+
+        const saved = await prisma.exam.findUnique({ where: { id: body.exam.id } });
+        expect(saved).not.toBeNull();
+        expect(saved?.createdByUserId).toBe(user.id);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadGenerateRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ session: 'AM' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+
+  it('returns 400 for an invalid session param', async () => {
+    const user = await createTestUser({ id: 'exam-gen-u2', email: 'exam-gen2@example.com' });
+    const appHandler = await loadGenerateRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ session: 'INVALID' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+});
+
+describe('POST /api/exam/[id]/start', () => {
+  beforeEach(resetUserData);
+
+  it('creates a new in-progress attempt', async () => {
+    const user = await createTestUser({ id: 'exam-start-u1', email: 'exam-start@example.com' });
+    const exam = await createTestExam(user.id);
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: exam.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.attemptId).toBeDefined();
+        expect(body.resumed).toBeUndefined();
+
+        const attempt = await prisma.examAttempt.findUnique({ where: { id: body.attemptId } });
+        expect(attempt).toMatchObject({ userId: user.id, examId: exam.id, status: 'IN_PROGRESS' });
+      },
+    });
+  });
+
+  it('resumes an existing in-progress attempt instead of creating a new one', async () => {
+    const user = await createTestUser({ id: 'exam-resume-u1', email: 'exam-resume@example.com' });
+    const exam = await createTestExam(user.id);
+    const existing = await prisma.examAttempt.create({ data: { userId: user.id, examId: exam.id } });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: exam.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.attemptId).toBe(existing.id);
+        expect(body.resumed).toBe(true);
+      },
+    });
+  });
+
+  it('returns 403 when the exam belongs to another user', async () => {
+    const owner = await createTestUser({ id: 'exam-owner-u1', email: 'owner@example.com' });
+    const attacker = await createTestUser({ id: 'exam-attacker-u1', email: 'attacker@example.com' });
+    const exam = await createTestExam(owner.id);
+    const appHandler = await loadStartRoute(sessionFor(attacker));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: exam.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+        expect(response.status).toBe(403);
+      },
+    });
+  });
+
+  it('returns 404 for a non-existent exam', async () => {
+    const user = await createTestUser({ id: 'exam-404-u1', email: 'exam404@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'non-existent-exam-id' },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadStartRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'any-exam-id' },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('POST /api/exam/[id]/answer', () => {
+  beforeEach(resetUserData);
+
+  it('saves a choice answer and upserts on re-answer', async () => {
+    const user = await createTestUser({ id: 'exam-ans-u1', email: 'exam-ans@example.com' });
+    const exam = await createTestExam(user.id);
+    const attempt = await prisma.examAttempt.create({ data: { userId: user.id, examId: exam.id } });
+    const option = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1' },
+    });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ questionId: 'test-question-1', selectedOptionId: option.id }),
+        });
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({ message: expect.any(String) });
+
+        const saved = await prisma.examAnswer.findFirst({
+          where: { examAttemptId: attempt.id, questionId: 'test-question-1' },
+        });
+        expect(saved?.selectedOptionId).toBe(option.id);
+      },
+    });
+  });
+
+  it('returns 404 when the attempt does not belong to the user', async () => {
+    const user = await createTestUser({ id: 'exam-ans-u2', email: 'exam-ans2@example.com' });
+    const other = await createTestUser({ id: 'exam-ans-u3', email: 'exam-ans3@example.com' });
+    const exam = await createTestExam(other.id);
+    const attempt = await prisma.examAttempt.create({ data: { userId: other.id, examId: exam.id } });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ questionId: 'test-question-1', selectedOptionId: 'some-opt' }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 400 when questionId is missing', async () => {
+    const user = await createTestUser({ id: 'exam-ans-u4', email: 'exam-ans4@example.com' });
+    const exam = await createTestExam(user.id);
+    const attempt = await prisma.examAttempt.create({ data: { userId: user.id, examId: exam.id } });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ selectedOptionId: 'some-option' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadAnswerRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'any-attempt-id' },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ questionId: 'test-question-1', selectedOptionId: 'opt' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('POST /api/exam/[id]/submit', () => {
+  beforeEach(resetUserData);
+
+  it('marks attempt COMPLETED and creates wrong note for a wrong choice answer', async () => {
+    const user = await createTestUser({ id: 'exam-sub-u1', email: 'exam-sub@example.com' });
+    const exam = await createTestExam(user.id);
+    const attempt = await prisma.examAttempt.create({ data: { userId: user.id, examId: exam.id } });
+    const wrongOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: false },
+    });
+    await prisma.examAnswer.create({
+      data: {
+        examAttemptId: attempt.id,
+        questionId: 'test-question-1',
+        selectedOptionId: wrongOption.id,
+        isCorrect: false,
+      },
+    });
+    const appHandler = await loadSubmitRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.totalScore).toBe(0);
+        expect(body.choiceScore).toBe(0);
+      },
+    });
+
+    const updated = await prisma.examAttempt.findUnique({ where: { id: attempt.id } });
+    expect(updated?.status).toBe('COMPLETED');
+
+    const wrongNote = await prisma.wrongNote.findFirst({
+      where: { userId: user.id, questionId: 'test-question-1' },
+    });
+    expect(wrongNote).not.toBeNull();
+  });
+
+  it('gives full score for a correct answer and does not create a wrong note', async () => {
+    const user = await createTestUser({ id: 'exam-sub-u2', email: 'exam-sub2@example.com' });
+    const exam = await createTestExam(user.id);
+    const attempt = await prisma.examAttempt.create({ data: { userId: user.id, examId: exam.id } });
+    const correctOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: true },
+    });
+    await prisma.examAnswer.create({
+      data: {
+        examAttemptId: attempt.id,
+        questionId: 'test-question-1',
+        selectedOptionId: correctOption.id,
+        isCorrect: true,
+      },
+    });
+    const appHandler = await loadSubmitRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.choiceScore).toBe(1);
+        expect(body.totalScore).toBe(1);
+      },
+    });
+
+    const wrongNote = await prisma.wrongNote.findFirst({
+      where: { userId: user.id, questionId: 'test-question-1' },
+    });
+    expect(wrongNote).toBeNull();
+  });
+
+  it('returns 409 when the exam has already been submitted', async () => {
+    const user = await createTestUser({ id: 'exam-sub-u3', email: 'exam-sub3@example.com' });
+    const exam = await createTestExam(user.id);
+    const attempt = await prisma.examAttempt.create({
+      data: {
+        userId: user.id,
+        examId: exam.id,
+        status: 'COMPLETED',
+        finishedAt: new Date(),
+        totalScore: 0,
+      },
+    });
+    const appHandler = await loadSubmitRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+        expect(response.status).toBe(409);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadSubmitRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'some-attempt-id' },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'POST' });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('GET /api/exam/[id]/result', () => {
+  beforeEach(resetUserData);
+
+  it('returns the completed attempt with exam details', async () => {
+    const user = await createTestUser({ id: 'exam-res-u1', email: 'exam-res@example.com' });
+    const exam = await createTestExam(user.id);
+    const attempt = await prisma.examAttempt.create({
+      data: {
+        userId: user.id,
+        examId: exam.id,
+        status: 'COMPLETED',
+        finishedAt: new Date(),
+        totalScore: 1,
+        choiceScore: 1,
+        caseScore: 0,
+      },
+    });
+    const appHandler = await loadResultRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.attempt.id).toBe(attempt.id);
+        expect(body.attempt.totalScore).toBe(1);
+        expect(body.previousScore).toBeNull();
+      },
+    });
+  });
+
+  it('returns 404 when the attempt does not belong to the user', async () => {
+    const user = await createTestUser({ id: 'exam-res-u2', email: 'exam-res2@example.com' });
+    const other = await createTestUser({ id: 'exam-res-u3', email: 'exam-res3@example.com' });
+    const exam = await createTestExam(other.id);
+    const attempt = await prisma.examAttempt.create({ data: { userId: other.id, examId: exam.id } });
+    const appHandler = await loadResultRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: attempt.id },
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadResultRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'some-attempt-id' },
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});

--- a/src/test/api-plan.test.ts
+++ b/src/test/api-plan.test.ts
@@ -54,6 +54,8 @@ describe('POST /api/plan/generate', () => {
     });
     const appHandler = await mockAIPlanGenerate(sessionFor(user), aiJson);
 
+    let planId!: string;
+
     await testApiHandler({
       appHandler,
       async test({ fetch }) {
@@ -65,15 +67,20 @@ describe('POST /api/plan/generate', () => {
 
         expect(response.status).toBe(200);
         const body = await response.json();
-        expect(body.plan).toBeDefined();
-        expect(body.plan.userId).toBe(user.id);
-        expect(body.plan.days.length).toBeGreaterThan(0);
+        expect(body.planId).toBeDefined();
+        expect(body.content).toBe('Test study plan overview');
+        planId = body.planId as string;
       },
     });
 
-    const saved = await prisma.studyPlan.findFirst({ where: { userId: user.id } });
+    const saved = await prisma.studyPlan.findUnique({
+      where: { id: planId },
+      include: { days: true },
+    });
     expect(saved).not.toBeNull();
-    expect(saved?.content).toBe('Test study plan overview');
+    expect(saved!.userId).toBe(user.id);
+    expect(saved!.days.length).toBeGreaterThan(0);
+    expect(saved!.content).toBe('Test study plan overview');
   });
 
   it('falls back to markdown parsing when AI returns non-JSON', async () => {
@@ -93,8 +100,13 @@ describe('POST /api/plan/generate', () => {
 
         expect(response.status).toBe(200);
         const body = await response.json();
-        expect(body.plan).toBeDefined();
-        expect(body.plan.days.length).toBeGreaterThan(0);
+        expect(body.planId).toBeDefined();
+        const saved = await prisma.studyPlan.findUnique({
+          where: { id: body.planId as string },
+          include: { days: true },
+        });
+        expect(saved).not.toBeNull();
+        expect(saved!.days.length).toBeGreaterThan(0);
       },
     });
   });

--- a/src/test/api-plan.test.ts
+++ b/src/test/api-plan.test.ts
@@ -1,0 +1,501 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import { createTestUser, resetUserData, sessionFor } from '@/test/helpers';
+
+async function loadPlanListRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/plan/route');
+}
+
+async function loadPlanDetailRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/plan/[id]/route');
+}
+
+async function loadPlanDayRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/plan/[id]/day/[dayNumber]/route');
+}
+
+function mockAIPlanGenerate(session: unknown, aiResponse: string) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  vi.doMock('@/lib/ai', () => ({
+    isAIConfigured: async () => true,
+    getAIProvider: async () => ({
+      name: 'Mock',
+      getInfo: () => ({ name: 'Mock', model: 'mock-model', endpoint: 'mock://ai' }),
+      createCompletion: async () => aiResponse,
+    }),
+  }));
+  vi.doMock('@/lib/ai/rate-limit', () => ({ checkAIRateLimit: () => true }));
+  return import('@/app/api/plan/generate/route');
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth');
+  vi.doUnmock('@/lib/ai');
+  vi.doUnmock('@/lib/ai/rate-limit');
+});
+
+describe('POST /api/plan/generate', () => {
+  beforeEach(resetUserData);
+
+  it('generates a study plan from a valid JSON AI response', async () => {
+    const user = await createTestUser({ id: 'plan-gen-u1', email: 'plan-gen@example.com' });
+    const aiJson = JSON.stringify({
+      overview: 'Test study plan overview',
+      days: [{ dayNumber: 1, tasks: ['复习数据库', '完成练习题', '整理错题笔记'] }],
+    });
+    const appHandler = await mockAIPlanGenerate(sessionFor(user), aiJson);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetDate: '2026-05-16', dailyTime: '2小时' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plan).toBeDefined();
+        expect(body.plan.userId).toBe(user.id);
+        expect(body.plan.days.length).toBeGreaterThan(0);
+      },
+    });
+
+    const saved = await prisma.studyPlan.findFirst({ where: { userId: user.id } });
+    expect(saved).not.toBeNull();
+    expect(saved?.content).toBe('Test study plan overview');
+  });
+
+  it('falls back to markdown parsing when AI returns non-JSON', async () => {
+    const user = await createTestUser({ id: 'plan-gen-u2', email: 'plan-gen2@example.com' });
+    const markdownResponse =
+      '- 复习数据库基础知识\n- 完成 15 道选择题\n- 整理薄弱知识点\n- 做模拟练习\n';
+    const appHandler = await mockAIPlanGenerate(sessionFor(user), markdownResponse);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetDate: '2026-05-16' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plan).toBeDefined();
+        expect(body.plan.days.length).toBeGreaterThan(0);
+      },
+    });
+  });
+
+  it('returns 400 for a missing or invalid targetDate', async () => {
+    const user = await createTestUser({ id: 'plan-gen-u3', email: 'plan-gen3@example.com' });
+    const appHandler = await mockAIPlanGenerate(sessionFor(user), '{}');
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetDate: 'not-a-date' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 429 when the AI rate limit is exceeded', async () => {
+    const user = await createTestUser({ id: 'plan-gen-u4', email: 'plan-gen4@example.com' });
+
+    vi.resetModules();
+    vi.doMock('@/lib/auth', () => ({ auth: async () => sessionFor(user) }));
+    vi.doMock('@/lib/ai', () => ({ isAIConfigured: async () => true }));
+    vi.doMock('@/lib/ai/rate-limit', () => ({ checkAIRateLimit: () => false }));
+    const appHandler = await import('@/app/api/plan/generate/route');
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetDate: '2026-05-16' }),
+        });
+        expect(response.status).toBe(429);
+      },
+    });
+  });
+
+  it('returns 503 when AI is not configured', async () => {
+    const user = await createTestUser({ id: 'plan-gen-u5', email: 'plan-gen5@example.com' });
+
+    vi.resetModules();
+    vi.doMock('@/lib/auth', () => ({ auth: async () => sessionFor(user) }));
+    vi.doMock('@/lib/ai', () => ({ isAIConfigured: async () => false }));
+    vi.doMock('@/lib/ai/rate-limit', () => ({ checkAIRateLimit: () => true }));
+    const appHandler = await import('@/app/api/plan/generate/route');
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetDate: '2026-05-16' }),
+        });
+        expect(response.status).toBe(503);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/auth', () => ({ auth: async () => null }));
+    vi.doMock('@/lib/ai', () => ({ isAIConfigured: async () => false }));
+    vi.doMock('@/lib/ai/rate-limit', () => ({ checkAIRateLimit: () => true }));
+    const appHandler = await import('@/app/api/plan/generate/route');
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetDate: '2026-05-16' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('GET /api/plan', () => {
+  beforeEach(resetUserData);
+
+  it('returns paginated study plans for the authenticated user', async () => {
+    const user = await createTestUser({ id: 'plan-list-u1', email: 'plan-list@example.com' });
+    await prisma.studyPlan.create({
+      data: {
+        userId: user.id,
+        title: 'Test Plan',
+        content: 'Overview',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 30,
+        days: { create: [{ dayNumber: 1, date: new Date('2026-05-02'), tasks: ['Task 1'] }] },
+      },
+    });
+    const appHandler = await loadPlanListRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plans.length).toBe(1);
+        expect(body.plans[0].title).toBe('Test Plan');
+        expect(body.pagination).toMatchObject({ page: 1, total: 1 });
+      },
+    });
+  });
+
+  it('returns an empty list for a user with no plans', async () => {
+    const user = await createTestUser({ id: 'plan-list-u2', email: 'plan-list2@example.com' });
+    const appHandler = await loadPlanListRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plans).toEqual([]);
+        expect(body.pagination.total).toBe(0);
+      },
+    });
+  });
+
+  it('isolates plans between users', async () => {
+    const user = await createTestUser({ id: 'plan-list-u3', email: 'plan-list3@example.com' });
+    const other = await createTestUser({ id: 'plan-list-u4', email: 'plan-list4@example.com' });
+    await prisma.studyPlan.create({
+      data: {
+        userId: other.id,
+        title: "Other User's Plan",
+        content: 'x',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 1,
+      },
+    });
+    const appHandler = await loadPlanListRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plans).toHaveLength(0);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadPlanListRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('GET /api/plan/[id]', () => {
+  beforeEach(resetUserData);
+
+  it('returns the plan with its days', async () => {
+    const user = await createTestUser({ id: 'plan-det-u1', email: 'plan-det@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: user.id,
+        title: 'My Detailed Plan',
+        content: 'Overview',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 1,
+        days: { create: [{ dayNumber: 1, date: new Date('2026-05-02'), tasks: ['Study'] }] },
+      },
+    });
+    const appHandler = await loadPlanDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id },
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plan.id).toBe(plan.id);
+        expect(body.plan.days.length).toBe(1);
+      },
+    });
+  });
+
+  it('returns 404 for another user\'s plan', async () => {
+    const user = await createTestUser({ id: 'plan-det-u2', email: 'plan-det2@example.com' });
+    const other = await createTestUser({ id: 'plan-det-u3', email: 'plan-det3@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: other.id,
+        title: 'Other Plan',
+        content: 'Overview',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 1,
+      },
+    });
+    const appHandler = await loadPlanDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id },
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+});
+
+describe('PATCH /api/plan/[id]', () => {
+  beforeEach(resetUserData);
+
+  it('updates plan status to COMPLETED', async () => {
+    const user = await createTestUser({ id: 'plan-patch-u1', email: 'plan-patch@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: user.id,
+        title: 'Plan to Complete',
+        content: 'Overview',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 5,
+      },
+    });
+    const appHandler = await loadPlanDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ status: 'COMPLETED' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.plan.status).toBe('COMPLETED');
+      },
+    });
+  });
+
+  it('returns 400 for an invalid status value', async () => {
+    const user = await createTestUser({ id: 'plan-patch-u2', email: 'plan-patch2@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: user.id,
+        title: 'Plan',
+        content: 'x',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 1,
+      },
+    });
+    const appHandler = await loadPlanDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ status: 'INVALID_STATUS' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 404 when updating another user\'s plan', async () => {
+    const user = await createTestUser({ id: 'plan-patch-u3', email: 'plan-patch3@example.com' });
+    const other = await createTestUser({ id: 'plan-patch-u4', email: 'plan-patch4@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: other.id,
+        title: 'Plan',
+        content: 'x',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 1,
+      },
+    });
+    const appHandler = await loadPlanDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ status: 'COMPLETED' }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+});
+
+describe('PATCH /api/plan/[id]/day/[dayNumber]', () => {
+  beforeEach(resetUserData);
+
+  it('marks a day as completed and saves notes', async () => {
+    const user = await createTestUser({ id: 'plan-day-u1', email: 'plan-day@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: user.id,
+        title: 'Daily Plan',
+        content: 'Overview',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 2,
+        days: {
+          create: [
+            { dayNumber: 1, date: new Date('2026-05-02'), tasks: ['Task 1'] },
+            { dayNumber: 2, date: new Date('2026-05-03'), tasks: ['Task 2'] },
+          ],
+        },
+      },
+    });
+    const appHandler = await loadPlanDayRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id, dayNumber: '1' },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ completed: true, notes: 'Finished all tasks today.' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.day.completed).toBe(true);
+        expect(body.day.notes).toBe('Finished all tasks today.');
+      },
+    });
+  });
+
+  it('returns 404 when the plan does not belong to the user', async () => {
+    const user = await createTestUser({ id: 'plan-day-u2', email: 'plan-day2@example.com' });
+    const other = await createTestUser({ id: 'plan-day-u3', email: 'plan-day3@example.com' });
+    const plan = await prisma.studyPlan.create({
+      data: {
+        userId: other.id,
+        title: 'Plan',
+        content: 'x',
+        targetExamDate: new Date('2026-06-01'),
+        totalDays: 1,
+        days: { create: [{ dayNumber: 1, date: new Date(), tasks: ['T'] }] },
+      },
+    });
+    const appHandler = await loadPlanDayRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: plan.id, dayNumber: '1' },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ completed: true }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadPlanDayRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'any-plan-id', dayNumber: '1' },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ completed: true }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});

--- a/src/test/api-practice-cases.test.ts
+++ b/src/test/api-practice-cases.test.ts
@@ -1,0 +1,312 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import {
+  TEST_CASE_QUESTION_ID,
+  TEST_CASE_SUB_IDS,
+  createTestUser,
+  resetUserData,
+  sessionFor,
+} from '@/test/helpers';
+
+async function loadCasesRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/cases/route');
+}
+
+async function loadCaseAnswerRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/cases/[id]/answer/route');
+}
+
+async function loadCaseResultRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/cases/[id]/result/route');
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth');
+});
+
+describe('GET /api/practice/cases', () => {
+  beforeEach(resetUserData);
+
+  it('lists available case questions with answered=false for a fresh user', async () => {
+    const user = await createTestUser({ id: 'cases-list-u1', email: 'cases-list@example.com' });
+    const appHandler = await loadCasesRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(Array.isArray(body.cases)).toBe(true);
+        expect(body.cases.length).toBeGreaterThan(0);
+
+        const caseItem = body.cases.find((c: { id: string }) => c.id === TEST_CASE_QUESTION_ID);
+        expect(caseItem).toBeDefined();
+        expect(caseItem?.answered).toBe(false);
+        expect(typeof caseItem?.score).toBe('number');
+      },
+    });
+  });
+
+  it('marks the case as answered when the user has a saved sub-question answer', async () => {
+    const user = await createTestUser({ id: 'cases-list-u2', email: 'cases-list2@example.com' });
+    await prisma.userCaseAnswer.create({
+      data: {
+        userId: user.id,
+        caseSubQuestionId: TEST_CASE_SUB_IDS[0],
+        answer: 'My answer',
+        score: 3,
+        feedback: 'Good',
+      },
+    });
+    const appHandler = await loadCasesRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        const caseItem = body.cases.find((c: { id: string }) => c.id === TEST_CASE_QUESTION_ID);
+        expect(caseItem?.answered).toBe(true);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadCasesRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('POST /api/practice/cases/[id]/answer', () => {
+  beforeEach(resetUserData);
+
+  it('grades with local keyword fallback when AI is not configured', async () => {
+    const user = await createTestUser({ id: 'case-ans-u1', email: 'case-ans@example.com' });
+    const subQuestions = await prisma.caseSubQuestion.findMany({
+      where: { caseScenarioId: 'test-case-scenario-1' },
+    });
+    const appHandler = await loadCaseAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: TEST_CASE_QUESTION_ID },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            answers: subQuestions.map((sub) => ({
+              caseSubQuestionId: sub.id,
+              answer: 'entities relationships keys primary foreign normalization',
+            })),
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.gradedBy).toBe('keyword');
+        expect(typeof body.totalScore).toBe('number');
+        expect(typeof body.maxScore).toBe('number');
+        expect(Array.isArray(body.results)).toBe(true);
+        expect(body.results.length).toBe(subQuestions.length);
+        for (const result of body.results) {
+          expect(typeof result.score).toBe('number');
+          expect(result.score).toBeGreaterThanOrEqual(0);
+        }
+      },
+    });
+
+    const saved = await prisma.userCaseAnswer.findMany({ where: { userId: user.id } });
+    expect(saved.length).toBe(subQuestions.length);
+  });
+
+  it('upserts answers so repeated submissions overwrite previous ones', async () => {
+    const user = await createTestUser({ id: 'case-ans-u2', email: 'case-ans2@example.com' });
+    const subQuestions = await prisma.caseSubQuestion.findMany({
+      where: { caseScenarioId: 'test-case-scenario-1' },
+    });
+    const appHandler = await loadCaseAnswerRoute(sessionFor(user));
+
+    const submit = async (answer: string) =>
+      testApiHandler({
+        appHandler,
+        params: { id: TEST_CASE_QUESTION_ID },
+        async test({ fetch }) {
+          const response = await fetch({
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              answers: [{ caseSubQuestionId: subQuestions[0].id, answer }],
+            }),
+          });
+          expect(response.status).toBe(200);
+        },
+      });
+
+    await submit('first answer attempt');
+    await submit('second answer attempt updated');
+
+    const saved = await prisma.userCaseAnswer.findMany({
+      where: { userId: user.id, caseSubQuestionId: subQuestions[0].id },
+    });
+    expect(saved.length).toBe(1);
+    expect(saved[0].answer).toBe('second answer attempt updated');
+  });
+
+  it('returns 400 when no answers are provided', async () => {
+    const user = await createTestUser({ id: 'case-ans-u3', email: 'case-ans3@example.com' });
+    const appHandler = await loadCaseAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: TEST_CASE_QUESTION_ID },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ answers: [] }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 404 for a non-existent case question', async () => {
+    const user = await createTestUser({ id: 'case-ans-u4', email: 'case-ans4@example.com' });
+    const appHandler = await loadCaseAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'non-existent-question-id' },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ answers: [{ caseSubQuestionId: 'sub-1', answer: 'test' }] }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadCaseAnswerRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: TEST_CASE_QUESTION_ID },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ answers: [{ caseSubQuestionId: 'sub-1', answer: 'answer' }] }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('GET /api/practice/cases/[id]/result', () => {
+  beforeEach(resetUserData);
+
+  it('returns the saved case answers for the user', async () => {
+    const user = await createTestUser({ id: 'case-res-u1', email: 'case-res@example.com' });
+    await prisma.userCaseAnswer.create({
+      data: {
+        userId: user.id,
+        caseSubQuestionId: TEST_CASE_SUB_IDS[0],
+        answer: 'My ER diagram answer',
+        score: 4,
+        feedback: 'Good coverage of entities',
+      },
+    });
+    const appHandler = await loadCaseResultRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: TEST_CASE_QUESTION_ID },
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(typeof body.totalScore).toBe('number');
+        expect(typeof body.maxScore).toBe('number');
+        expect(Array.isArray(body.results)).toBe(true);
+
+        const sub = body.results.find(
+          (r: { subQuestionId: string }) => r.subQuestionId === TEST_CASE_SUB_IDS[0]
+        );
+        expect(sub?.score).toBe(4);
+        expect(sub?.answer).toBe('My ER diagram answer');
+      },
+    });
+  });
+
+  it('returns null scores when no answers have been submitted yet', async () => {
+    const user = await createTestUser({ id: 'case-res-u2', email: 'case-res2@example.com' });
+    const appHandler = await loadCaseResultRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: TEST_CASE_QUESTION_ID },
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.totalScore).toBe(0);
+        for (const r of body.results) {
+          expect(r.score).toBeNull();
+        }
+      },
+    });
+  });
+
+  it('returns 404 for a non-existent case question', async () => {
+    const user = await createTestUser({ id: 'case-res-u3', email: 'case-res3@example.com' });
+    const appHandler = await loadCaseResultRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'non-existent-question' },
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadCaseResultRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: TEST_CASE_QUESTION_ID },
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});

--- a/src/test/api-practice.test.ts
+++ b/src/test/api-practice.test.ts
@@ -305,8 +305,9 @@ describe('GET /api/practice/summary', () => {
 
     await testApiHandler({
       appHandler,
+      url: `/?sessionId=${practiceSession.id}`,
       async test({ fetch }) {
-        const response = await fetch(`/?sessionId=${practiceSession.id}`);
+        const response = await fetch();
 
         expect(response.status).toBe(200);
         const body = await response.json();
@@ -340,8 +341,9 @@ describe('GET /api/practice/summary', () => {
 
     await testApiHandler({
       appHandler,
+      url: `/?sessionId=${practiceSession.id}`,
       async test({ fetch }) {
-        const response = await fetch(`/?sessionId=${practiceSession.id}`);
+        const response = await fetch();
         expect(response.status).toBe(404);
       },
     });
@@ -352,8 +354,9 @@ describe('GET /api/practice/summary', () => {
 
     await testApiHandler({
       appHandler,
+      url: '/?sessionId=any-session-id',
       async test({ fetch }) {
-        const response = await fetch('/?sessionId=any-session-id');
+        const response = await fetch();
         expect(response.status).toBe(401);
       },
     });

--- a/src/test/api-practice.test.ts
+++ b/src/test/api-practice.test.ts
@@ -1,0 +1,361 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import {
+  createTestPracticeSession,
+  createTestUser,
+  resetUserData,
+  sessionFor,
+} from '@/test/helpers';
+
+async function loadStartRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/start/route');
+}
+
+async function loadAnswerRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/answer/route');
+}
+
+async function loadSummaryRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/summary/route');
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth');
+});
+
+describe('POST /api/practice/start', () => {
+  beforeEach(resetUserData);
+
+  it('creates a random-mode practice session and strips correct-answer flags', async () => {
+    const user = await createTestUser({ id: 'prac-start-u1', email: 'prac-start@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'random', limit: 5 }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.sessionId).toBeDefined();
+        expect(Array.isArray(body.questions)).toBe(true);
+        expect(body.questions.length).toBeGreaterThan(0);
+        for (const q of body.questions) {
+          expect(q).not.toHaveProperty('isCorrect');
+          for (const opt of q.options ?? []) {
+            expect(opt).not.toHaveProperty('isCorrect');
+          }
+        }
+
+        const saved = await prisma.practiceSession.findUnique({ where: { id: body.sessionId } });
+        expect(saved?.userId).toBe(user.id);
+        expect(saved?.mode).toBe('random');
+      },
+    });
+  });
+
+  it('creates a sequential-mode session with a single question', async () => {
+    const user = await createTestUser({ id: 'prac-start-u2', email: 'prac-start2@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 1 }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.questions.length).toBe(1);
+      },
+    });
+  });
+
+  it('returns 400 for an invalid mode', async () => {
+    const user = await createTestUser({ id: 'prac-start-u3', email: 'prac-start3@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'invalid-mode' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadStartRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'random' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('POST /api/practice/answer', () => {
+  beforeEach(resetUserData);
+
+  it('records a correct answer without creating a wrong note', async () => {
+    const user = await createTestUser({ id: 'prac-ans-u1', email: 'prac-ans@example.com' });
+    const session = await createTestPracticeSession(user.id);
+    const correctOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: true },
+    });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: session.id,
+            questionId: 'test-question-1',
+            selectedOptionId: correctOption.id,
+            timeSpent: 30,
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.isCorrect).toBe(true);
+        expect(body.correctOptionId).toBe(correctOption.id);
+        expect(body.explanation).toBeDefined();
+      },
+    });
+
+    const wrongNote = await prisma.wrongNote.findFirst({
+      where: { userId: user.id, questionId: 'test-question-1' },
+    });
+    expect(wrongNote).toBeNull();
+  });
+
+  it('records a wrong answer and auto-creates a wrong note', async () => {
+    const user = await createTestUser({ id: 'prac-ans-u2', email: 'prac-ans2@example.com' });
+    const session = await createTestPracticeSession(user.id);
+    const wrongOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: false },
+    });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: session.id,
+            questionId: 'test-question-1',
+            selectedOptionId: wrongOption.id,
+            timeSpent: 20,
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.isCorrect).toBe(false);
+      },
+    });
+
+    const wrongNote = await prisma.wrongNote.findFirst({
+      where: { userId: user.id, questionId: 'test-question-1' },
+    });
+    expect(wrongNote).not.toBeNull();
+    expect(wrongNote?.markedMastered).toBe(false);
+  });
+
+  it('marks the session as completed when the last question is answered', async () => {
+    const user = await createTestUser({ id: 'prac-ans-u3', email: 'prac-ans3@example.com' });
+    const session = await createTestPracticeSession(user.id, ['test-question-1']);
+    const option = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1' },
+    });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: session.id,
+            questionId: 'test-question-1',
+            selectedOptionId: option.id,
+            timeSpent: 15,
+          }),
+        });
+      },
+    });
+
+    const updated = await prisma.practiceSession.findUnique({ where: { id: session.id } });
+    expect(updated?.completedAt).not.toBeNull();
+  });
+
+  it('returns 403 when the session does not belong to the user', async () => {
+    const user = await createTestUser({ id: 'prac-ans-u4', email: 'prac-ans4@example.com' });
+    const other = await createTestUser({ id: 'prac-ans-u5', email: 'prac-ans5@example.com' });
+    const session = await createTestPracticeSession(other.id);
+    const option = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1' },
+    });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: session.id,
+            questionId: 'test-question-1',
+            selectedOptionId: option.id,
+          }),
+        });
+        expect(response.status).toBe(403);
+      },
+    });
+  });
+
+  it('returns 400 when required parameters are missing', async () => {
+    const user = await createTestUser({ id: 'prac-ans-u6', email: 'prac-ans6@example.com' });
+    const appHandler = await loadAnswerRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ questionId: 'test-question-1' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadAnswerRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ questionId: 'test-question-1', selectedOptionId: 'opt' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('GET /api/practice/summary', () => {
+  beforeEach(resetUserData);
+
+  it('returns accuracy stats for a completed session', async () => {
+    const user = await createTestUser({ id: 'prac-sum-u1', email: 'prac-sum@example.com' });
+    const practiceSession = await createTestPracticeSession(user.id, ['test-question-1']);
+    const correctOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: true },
+    });
+    await prisma.userAnswer.create({
+      data: {
+        userId: user.id,
+        questionId: 'test-question-1',
+        selectedOptionId: correctOption.id,
+        practiceSessionId: practiceSession.id,
+        isCorrect: true,
+        timeSpent: 30,
+      },
+    });
+    const appHandler = await loadSummaryRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch(`/?sessionId=${practiceSession.id}`);
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.total).toBe(1);
+        expect(body.answered).toBe(1);
+        expect(body.correct).toBe(1);
+        expect(body.accuracy).toBe(100);
+        expect(typeof body.timeSpent).toBe('number');
+      },
+    });
+  });
+
+  it('returns 400 when sessionId is missing', async () => {
+    const user = await createTestUser({ id: 'prac-sum-u2', email: 'prac-sum2@example.com' });
+    const appHandler = await loadSummaryRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 404 when the session does not belong to the user', async () => {
+    const user = await createTestUser({ id: 'prac-sum-u3', email: 'prac-sum3@example.com' });
+    const other = await createTestUser({ id: 'prac-sum-u4', email: 'prac-sum4@example.com' });
+    const practiceSession = await createTestPracticeSession(other.id);
+    const appHandler = await loadSummaryRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch(`/?sessionId=${practiceSession.id}`);
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadSummaryRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch('/?sessionId=any-session-id');
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});

--- a/src/test/api-profile-wrong-notes.test.ts
+++ b/src/test/api-profile-wrong-notes.test.ts
@@ -1,0 +1,452 @@
+import bcrypt from 'bcryptjs';
+import { testApiHandler } from 'next-test-api-route-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import { createTestUser, resetUserData, sessionFor } from '@/test/helpers';
+
+async function loadProfileRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/profile/route');
+}
+
+async function loadPasswordRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/profile/password/route');
+}
+
+async function loadWrongNotesRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/wrong-notes/route');
+}
+
+async function loadWrongNoteDetailRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/wrong-notes/[id]/route');
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth');
+});
+
+describe('PATCH /api/profile', () => {
+  beforeEach(resetUserData);
+
+  it('updates the display name', async () => {
+    const user = await createTestUser({ id: 'profile-u1', email: 'profile@example.com' });
+    const appHandler = await loadProfileRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'Updated Name' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.user.name).toBe('Updated Name');
+      },
+    });
+
+    const saved = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(saved?.name).toBe('Updated Name');
+  });
+
+  it('updates the target exam date', async () => {
+    const user = await createTestUser({ id: 'profile-u2', email: 'profile2@example.com' });
+    const appHandler = await loadProfileRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetExamDate: '2026-11-01' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.user.targetExamDate).toBeDefined();
+      },
+    });
+  });
+
+  it('clears the target exam date when set to null', async () => {
+    const user = await createTestUser({ id: 'profile-u3', email: 'profile3@example.com' });
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { targetExamDate: new Date('2026-11-01') },
+    });
+    const appHandler = await loadProfileRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetExamDate: null }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.user.targetExamDate).toBeNull();
+      },
+    });
+  });
+
+  it('returns 400 for an invalid exam date string', async () => {
+    const user = await createTestUser({ id: 'profile-u4', email: 'profile4@example.com' });
+    const appHandler = await loadProfileRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ targetExamDate: 'not-a-date' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 400 for an empty or whitespace-only name', async () => {
+    const user = await createTestUser({ id: 'profile-u5', email: 'profile5@example.com' });
+    const appHandler = await loadProfileRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: '   ' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadProfileRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'New Name' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('PATCH /api/profile/password', () => {
+  beforeEach(resetUserData);
+
+  it('updates the password when the old password is correct', async () => {
+    const plainPassword = 'old-password-123';
+    const hashedPassword = bcrypt.hashSync(plainPassword, 1);
+    const user = await prisma.user.create({
+      data: {
+        id: 'pw-u1',
+        email: 'pw@example.com',
+        name: 'PW User',
+        password: hashedPassword,
+      },
+    });
+    const appHandler = await loadPasswordRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ oldPassword: plainPassword, newPassword: 'new-secure-password' }),
+        });
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({ message: expect.any(String) });
+      },
+    });
+
+    const updated = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { password: true },
+    });
+    const valid = await bcrypt.compare('new-secure-password', updated!.password);
+    expect(valid).toBe(true);
+  });
+
+  it('returns 400 when the old password is incorrect', async () => {
+    const user = await createTestUser({ id: 'pw-u2', email: 'pw2@example.com' });
+    const appHandler = await loadPasswordRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ oldPassword: 'wrong-password', newPassword: 'new-secure-password' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 400 when the new password is too short', async () => {
+    const user = await createTestUser({ id: 'pw-u3', email: 'pw3@example.com' });
+    const appHandler = await loadPasswordRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ oldPassword: 'any-old', newPassword: '123' }),
+        });
+        expect(response.status).toBe(400);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadPasswordRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ oldPassword: 'any', newPassword: 'new-password' }),
+        });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('GET /api/wrong-notes', () => {
+  beforeEach(resetUserData);
+
+  it('returns the user\'s wrong notes with question details', async () => {
+    const user = await createTestUser({ id: 'wn-list-u1', email: 'wn-list@example.com' });
+    const wrongOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: false },
+    });
+    await prisma.userAnswer.create({
+      data: {
+        userId: user.id,
+        questionId: 'test-question-1',
+        selectedOptionId: wrongOption.id,
+        isCorrect: false,
+        timeSpent: 10,
+      },
+    });
+    await prisma.wrongNote.create({ data: { userId: user.id, questionId: 'test-question-1' } });
+    const appHandler = await loadWrongNotesRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.items.length).toBe(1);
+        expect(body.items[0].question.id).toBe('test-question-1');
+        expect(body.stats.total).toBe(1);
+        expect(body.stats.unmastered).toBe(1);
+      },
+    });
+  });
+
+  it('isolates wrong notes between users', async () => {
+    const user = await createTestUser({ id: 'wn-list-u2', email: 'wn-list2@example.com' });
+    const other = await createTestUser({ id: 'wn-list-u3', email: 'wn-list3@example.com' });
+    const wrongOption = await prisma.questionOption.findFirstOrThrow({
+      where: { questionId: 'test-question-1', isCorrect: false },
+    });
+    await prisma.userAnswer.create({
+      data: {
+        userId: other.id,
+        questionId: 'test-question-1',
+        selectedOptionId: wrongOption.id,
+        isCorrect: false,
+        timeSpent: 10,
+      },
+    });
+    await prisma.wrongNote.create({ data: { userId: other.id, questionId: 'test-question-1' } });
+    const appHandler = await loadWrongNotesRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.items).toHaveLength(0);
+        expect(body.stats.total).toBe(0);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadWrongNotesRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch();
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});
+
+describe('PATCH /api/wrong-notes/[id]', () => {
+  beforeEach(resetUserData);
+
+  it('marks a wrong note as mastered', async () => {
+    const user = await createTestUser({ id: 'wn-patch-u1', email: 'wn-patch@example.com' });
+    const note = await prisma.wrongNote.create({
+      data: { userId: user.id, questionId: 'test-question-1' },
+    });
+    const appHandler = await loadWrongNoteDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: note.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ markedMastered: true }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.item.markedMastered).toBe(true);
+      },
+    });
+  });
+
+  it('updates the note text', async () => {
+    const user = await createTestUser({ id: 'wn-patch-u2', email: 'wn-patch2@example.com' });
+    const note = await prisma.wrongNote.create({
+      data: { userId: user.id, questionId: 'test-question-1' },
+    });
+    const appHandler = await loadWrongNoteDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: note.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ note: 'Remember: option A is correct due to X.' }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.item.note).toBe('Remember: option A is correct due to X.');
+      },
+    });
+  });
+
+  it('returns 404 when trying to update another user\'s note', async () => {
+    const user = await createTestUser({ id: 'wn-patch-u3', email: 'wn-patch3@example.com' });
+    const other = await createTestUser({ id: 'wn-patch-u4', email: 'wn-patch4@example.com' });
+    const note = await prisma.wrongNote.create({
+      data: { userId: other.id, questionId: 'test-question-1' },
+    });
+    const appHandler = await loadWrongNoteDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: note.id },
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ markedMastered: true }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+});
+
+describe('DELETE /api/wrong-notes/[id]', () => {
+  beforeEach(resetUserData);
+
+  it('removes the wrong note from the database', async () => {
+    const user = await createTestUser({ id: 'wn-del-u1', email: 'wn-del@example.com' });
+    const note = await prisma.wrongNote.create({
+      data: { userId: user.id, questionId: 'test-question-1' },
+    });
+    const appHandler = await loadWrongNoteDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: note.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'DELETE' });
+        expect(response.status).toBe(200);
+      },
+    });
+
+    const deleted = await prisma.wrongNote.findUnique({ where: { id: note.id } });
+    expect(deleted).toBeNull();
+  });
+
+  it('returns 404 when trying to delete another user\'s note', async () => {
+    const user = await createTestUser({ id: 'wn-del-u2', email: 'wn-del2@example.com' });
+    const other = await createTestUser({ id: 'wn-del-u3', email: 'wn-del3@example.com' });
+    const note = await prisma.wrongNote.create({
+      data: { userId: other.id, questionId: 'test-question-1' },
+    });
+    const appHandler = await loadWrongNoteDetailRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      params: { id: note.id },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'DELETE' });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const appHandler = await loadWrongNoteDetailRoute(null);
+
+    await testApiHandler({
+      appHandler,
+      params: { id: 'any-note-id' },
+      async test({ fetch }) {
+        const response = await fetch({ method: 'DELETE' });
+        expect(response.status).toBe(401);
+      },
+    });
+  });
+});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -2,6 +2,10 @@ import { prisma } from '@/lib/prisma';
 
 const TEST_PASSWORD_HASH = '$2a$12$CwTycUXWue0Thq9StjUM0uJ8.lVvnV4dEDqQ3oYBE1zxOzl1sQVIu';
 
+export const TEST_CASE_QUESTION_ID = 'test-case-question-1';
+export const TEST_CASE_SCENARIO_ID = 'test-case-scenario-1';
+export const TEST_CASE_SUB_IDS = ['test-sub-q-1', 'test-sub-q-2'] as const;
+
 export async function resetUserData() {
   await prisma.user.deleteMany();
 }
@@ -27,4 +31,39 @@ export function sessionFor(user: { id: string; email: string; name: string }) {
       name: user.name,
     },
   };
+}
+
+export async function createTestExam(
+  userId: string,
+  questionIds: string[] = ['test-question-1']
+) {
+  return prisma.exam.create({
+    data: {
+      title: 'Test Mock Exam',
+      type: 'MOCK',
+      session: 'AM',
+      timeLimit: 150,
+      totalScore: questionIds.length,
+      createdByUserId: userId,
+      questions: {
+        create: questionIds.map((qId, i) => ({ questionId: qId, orderNumber: i + 1 })),
+      },
+    },
+  });
+}
+
+export async function createTestPracticeSession(
+  userId: string,
+  questionIds: string[] = ['test-question-1']
+) {
+  return prisma.practiceSession.create({
+    data: {
+      userId,
+      mode: 'random',
+      total: questionIds.length,
+      questions: {
+        create: questionIds.map((id, i) => ({ questionId: id, order: i + 1 })),
+      },
+    },
+  });
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -91,6 +91,67 @@ async function seedMinimalQuestionBank() {
   }
 }
 
+async function seedCaseQuestion() {
+  await prisma.question.upsert({
+    where: { id: 'test-case-question-1' },
+    update: {
+      content: 'A company needs to design a database management system for its operations.',
+      type: 'CASE_ANALYSIS',
+    },
+    create: {
+      id: 'test-case-question-1',
+      content: 'A company needs to design a database management system for its operations.',
+      type: 'CASE_ANALYSIS',
+      difficulty: 2,
+      year: 2097,
+      session: 'PM',
+      questionNumber: 1,
+      explanation: 'Database design involves ER modeling and normalization.',
+      knowledgePointId: 'test-child',
+      isAIGenerated: false,
+      aiGeneratedBy: null,
+      createdByUserId: null,
+    },
+  });
+
+  await prisma.caseScenario.upsert({
+    where: { questionId: 'test-case-question-1' },
+    update: { background: 'A company has products, customers, and orders. Design an appropriate database.' },
+    create: {
+      id: 'test-case-scenario-1',
+      questionId: 'test-case-question-1',
+      background: 'A company has products, customers, and orders. Design an appropriate database.',
+    },
+  });
+
+  for (const sub of [
+    {
+      id: 'test-sub-q-1',
+      subNumber: 1,
+      content: 'Design the ER diagram for the company database.',
+      answerType: 'SHORT_ANSWER' as const,
+      referenceAnswer: 'entities relationships keys primary foreign',
+      score: 5,
+      explanation: 'Identify entities, attributes, and relationships.',
+    },
+    {
+      id: 'test-sub-q-2',
+      subNumber: 2,
+      content: 'Normalize the schema to 3NF.',
+      answerType: 'SHORT_ANSWER' as const,
+      referenceAnswer: 'normalization normal form functional dependency',
+      score: 5,
+      explanation: 'Apply normalization rules to remove redundancy.',
+    },
+  ]) {
+    await prisma.caseSubQuestion.upsert({
+      where: { id: sub.id },
+      update: { referenceAnswer: sub.referenceAnswer },
+      create: { ...sub, caseScenarioId: 'test-case-scenario-1' },
+    });
+  }
+}
+
 async function prepareDatabase() {
   const prismaCli = require.resolve('prisma/build/index.js');
   execFileSync(
@@ -103,6 +164,7 @@ async function prepareDatabase() {
     }
   );
   await seedMinimalQuestionBank();
+  await seedCaseQuestion();
 }
 
 const globalForSetup = globalThis as typeof globalThis & {


### PR DESCRIPTION
Closes #31

新增 5 个测试文件，覆盖模拟考试、练习答题、案例题批改、学习计划和个人中心/错题本等核心路径。每条路径均包含成功用例、越权/未登录用例和边界失败用例。

Generated with [Claude Code](https://claude.ai/code)