### PR TITLE
fix: address CodeQL HTML sanitization alerts

### DIFF
--- a/scripts/classify-51cto-questions.ts
+++ b/scripts/classify-51cto-questions.ts
@@ -21,6 +21,7 @@ import { getAIProvider, resolveAIConfig } from '@/lib/ai/index';
 import { parseAIJson } from '@/lib/ai/json';
 import { prisma } from '@/lib/prisma';
 import { KNOWLEDGE_TREE, leafKnowledgePoints } from '@/prisma/knowledge-tree';
+import { htmlToText } from '@/lib/utils/html-to-text';
 
 const SEED_PATH = path.resolve(process.cwd(), 'data/51cto-seed.json');
 const CLASS_PATH = path.resolve(process.cwd(), 'data/51cto-classifications.json');
@@ -91,17 +92,7 @@ type RawClassification = {
 // ---------- Helpers ----------
 
 function stripHtml(s: string): string {
-  return (s ?? '')
-    .replace(/<img[^>]*>/gi, '[图]')
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
+  return htmlToText(s)
     .replace(/[ \t]+/g, ' ')
     .replace(/\n{3,}/g, '\n\n')
     .trim();

--- a/src/lib/ai/learning-context.ts
+++ b/src/lib/ai/learning-context.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { getUserAnalysis } from '@/lib/analysis';
 import { getChinaDateKey, getTodayRange } from '@/lib/stats';
 import { getOrSetAnalysis, getOrSetStable } from '@/lib/ai/context-cache';
+import { htmlToText } from '@/lib/utils/html-to-text';
 
 const MAX_CONTEXT_CHARS = 18_000;
 const MAX_TODAY_CHOICE_DETAILS = 80;
@@ -48,24 +49,6 @@ type ChoiceAnswerDetail = {
   question: QuestionLike;
   examTitle?: string;
 };
-
-function decodeBasicEntities(value: string) {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'");
-}
-
-function htmlToText(value: string) {
-  return decodeBasicEntities(value)
-    .replace(/<img\b[^>]*\bsrc=["']?([^"'\s>]+)["']?[^>]*>/gi, ' [图片:$1] ')
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n')
-    .replace(/<[^>]+>/g, ' ');
-}
 
 function compactText(value: string | null | undefined, maxLength: number) {
   const text = htmlToText(value ?? '')

--- a/src/lib/utils/html-to-text.ts
+++ b/src/lib/utils/html-to-text.ts
@@ -4,6 +4,8 @@
  * Safety properties:
  *  - Two-pass tag stripping: once before and once after entity decoding,
  *    so entities like &lt;script&gt; cannot survive as tags in the output.
+ *  - Second pass uses /<[a-zA-Z\/!][^>]*>/g so only valid tag starters are
+ *    stripped; decoded text like "< b >" (space-leading) is preserved as-is.
  *  - &amp; is decoded last, preventing double-unescaping of sequences like
  *    &amp;lt; (which would otherwise become < via &amp;→& then &lt;→<).
  *  - <img> src is preserved as a [图片:URL] placeholder.
@@ -20,5 +22,5 @@ export function htmlToText(html: string): string {
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
     .replace(/&amp;/gi, '&')
-    .replace(/<[^>]+>/g, ' ');
+    .replace(/<[a-zA-Z\/!][^>]*>/g, ' ');
 }

--- a/src/lib/utils/html-to-text.ts
+++ b/src/lib/utils/html-to-text.ts
@@ -1,0 +1,24 @@
+/**
+ * Converts an HTML string to plain text suitable for AI context/prompts.
+ *
+ * Safety properties:
+ *  - Two-pass tag stripping: once before and once after entity decoding,
+ *    so entities like &lt;script&gt; cannot survive as tags in the output.
+ *  - &amp; is decoded last, preventing double-unescaping of sequences like
+ *    &amp;lt; (which would otherwise become < via &amp;→& then &lt;→<).
+ *  - <img> src is preserved as a [图片:URL] placeholder.
+ */
+export function htmlToText(html: string): string {
+  return (html ?? '')
+    .replace(/<img\b[^>]*\bsrc=["']?([^"'\s>]+)["']?[^>]*>/gi, ' [图片:$1] ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&amp;/gi, '&')
+    .replace(/<[^>]+>/g, ' ');
+}

--- a/src/test/html-to-text.test.ts
+++ b/src/test/html-to-text.test.ts
@@ -39,6 +39,8 @@ describe('htmlToText', () => {
   });
 
   it('decodes &lt; and &gt;', () => {
+    // Decoded "< b >" starts with a space so the second-pass tag stripper
+    // (which only matches /<[a-zA-Z\/!]...>/) leaves it intact.
     expect(htmlToText('a &lt; b &gt; c')).toBe('a < b > c');
   });
 
@@ -81,10 +83,10 @@ describe('htmlToText', () => {
     const input =
       '<p>Q: which of <b>these</b> is right?</p><img src="img.png"><br/>Answer: &lt;A&gt; &amp; &lt;B&gt;';
     const result = htmlToText(input);
+    // &lt;A&gt; and &lt;B&gt; decode to <A> and <B>; the second pass strips them
+    // because they start with a letter — consistent with stripping real HTML tags.
     expect(result).not.toMatch(/<[a-zA-Z]/);
     expect(result).toContain('[图片:img.png]');
-    expect(result).toContain('<A>');
-    expect(result).toContain('<B>');
     expect(result).toContain('&');
   });
 });

--- a/src/test/html-to-text.test.ts
+++ b/src/test/html-to-text.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { htmlToText } from '@/lib/utils/html-to-text';
+
+describe('htmlToText', () => {
+  it('returns empty string for empty input', () => {
+    expect(htmlToText('')).toBe('');
+  });
+
+  it('handles null-like input via nullish coalescing', () => {
+    expect(htmlToText(undefined as unknown as string)).toBe('');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(htmlToText('hello world')).toBe('hello world');
+  });
+
+  it('strips basic HTML tags', () => {
+    expect(htmlToText('<p>hello</p>')).toBe(' hello\n');
+  });
+
+  it('converts <br> to newline', () => {
+    expect(htmlToText('line1<br>line2')).toBe('line1\nline2');
+    expect(htmlToText('line1<br/>line2')).toBe('line1\nline2');
+  });
+
+  it('converts </p> to newline', () => {
+    expect(htmlToText('<p>para</p>')).toBe(' para\n');
+  });
+
+  it('converts <img src> to placeholder', () => {
+    expect(htmlToText('<img src="http://example.com/img.png" alt="x">')).toContain(
+      '[图片:http://example.com/img.png]'
+    );
+  });
+
+  it('converts <img src> with single-quoted src to placeholder', () => {
+    expect(htmlToText("<img src='pic.jpg'>")).toContain('[图片:pic.jpg]');
+  });
+
+  it('decodes &lt; and &gt;', () => {
+    expect(htmlToText('a &lt; b &gt; c')).toBe('a < b > c');
+  });
+
+  it('decodes &amp; last — &amp;lt; becomes &lt; not <', () => {
+    // Double-encoded: &amp;lt; should yield &lt;, NOT <
+    expect(htmlToText('&amp;lt;')).toBe('&lt;');
+  });
+
+  it('decodes &amp; to & for normal ampersands', () => {
+    expect(htmlToText('a &amp; b')).toBe('a & b');
+  });
+
+  it('decodes &quot; and &#39;', () => {
+    expect(htmlToText('say &quot;hello&quot; &amp; it&#39;s fine')).toBe(
+      "say \"hello\" & it's fine"
+    );
+  });
+
+  it('decodes &nbsp; to space', () => {
+    expect(htmlToText('a&nbsp;b')).toBe('a b');
+  });
+
+  // CodeQL alert #1 — incomplete multi-character sanitization
+  it('strips tags introduced by &lt;/&gt; entity decoding (second pass)', () => {
+    // &lt;script&gt; becomes <script> after entity decode — second pass strips it
+    const result = htmlToText('&lt;script&gt;alert()&lt;/script&gt;');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('</script');
+    expect(result).toContain('alert()');
+  });
+
+  // CodeQL alerts #2 & #3 — double-escaping / double-unescaping
+  it('does not double-unescape &amp;lt; into <', () => {
+    const result = htmlToText('&amp;lt;script&amp;gt;alert()&amp;lt;/script&amp;gt;');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('</script');
+  });
+
+  it('strips residual tags in complex mixed content', () => {
+    const input =
+      '<p>Q: which of <b>these</b> is right?</p><img src="img.png"><br/>Answer: &lt;A&gt; &amp; &lt;B&gt;';
+    const result = htmlToText(input);
+    expect(result).not.toMatch(/<[a-zA-Z]/);
+    expect(result).toContain('[图片:img.png]');
+    expect(result).toContain('<A>');
+    expect(result).toContain('<B>');
+    expect(result).toContain('&');
+  });
+});


### PR DESCRIPTION
Fixes #40

Addresses all 3 open CodeQL alerts:

- `js/incomplete-multi-character-sanitization` in `scripts/classify-51cto-questions.ts`
- `js/double-escaping` in `scripts/classify-51cto-questions.ts`
- `js/double-escaping` in `src/lib/ai/learning-context.ts`

Changes:

- Introduces shared `src/lib/utils/html-to-text.ts` helper.
- Performs tag stripping before and after entity decoding.
- Decodes `&amp;` last to avoid double-unescaping.
- Preserves image placeholders for AI context.
- Adds focused tests in `src/test/html-to-text.test.ts`.

Generated with [Claude Code](https://claude.ai/code)