### PR TITLE
feat: question-level answer history and practice filtering

### DIFF
--- a/src/app/(main)/practice/page.tsx
+++ b/src/app/(main)/practice/page.tsx
@@ -3,15 +3,13 @@ import {
   BookOpenCheck,
   ClipboardPenLine,
   Layers3,
-  Shuffle,
-  ListOrdered,
   Sparkles,
 } from 'lucide-react';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { StartPracticeButton } from '@/components/start-practice-button';
+import { PracticeFilterCards } from '@/components/practice-filter-cards';
 import { getTopicAnswerStats, loadKnowledgeTree, rollupStats } from '@/lib/knowledge-stats';
 
 const colorClasses = ['bg-softYellow', 'bg-softBlue', 'bg-softRose', 'bg-softGreen'];
@@ -56,26 +54,7 @@ export default async function PracticePage() {
               </Button>
             </div>
           </Card>
-          <Card className="bg-softBlue p-6 sm:p-7">
-            <Shuffle className="h-10 w-10 text-primary" />
-            <h2 className="mt-5 text-2xl font-black text-navy">随机练习</h2>
-            <p className="mt-2 font-semibold text-muted">从题库随机抽取 20 题，适合快速热身。</p>
-            <div className="mt-6">
-              <StartPracticeButton payload={{ mode: 'random', limit: 20 }}>
-                开始随机练习
-              </StartPracticeButton>
-            </div>
-          </Card>
-          <Card className="bg-softGreen p-6 sm:p-7">
-            <ListOrdered className="h-10 w-10 text-primary" />
-            <h2 className="mt-5 text-2xl font-black text-navy">顺序练习</h2>
-            <p className="mt-2 font-semibold text-muted">按年份和题号顺序推进，适合系统训练。</p>
-            <div className="mt-6">
-              <StartPracticeButton payload={{ mode: 'sequential', limit: 20 }} variant="secondary">
-                开始顺序练习
-              </StartPracticeButton>
-            </div>
-          </Card>
+          <PracticeFilterCards />
           <Card className="bg-[#E9D5FF]/70 p-6 sm:p-7">
             <ClipboardPenLine className="h-10 w-10 text-primary" />
             <h2 className="mt-5 text-2xl font-black text-navy">案例分析练习</h2>

--- a/src/app/(main)/practice/topic/[id]/page.tsx
+++ b/src/app/(main)/practice/topic/[id]/page.tsx
@@ -1,20 +1,26 @@
-﻿import Link from 'next/link';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { ArrowLeft, FileQuestion } from 'lucide-react';
 import { prisma } from '@/lib/prisma';
+import { auth } from '@/lib/auth';
 import { getDescendantTopicIds } from '@/lib/knowledge-stats';
+import { getQuestionHistory, type QuestionHistoryEntry } from '@/lib/question-history';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { StartPracticeButton } from '@/components/start-practice-button';
 
 export default async function TopicPracticePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const topic = await prisma.knowledgePoint.findUnique({
-    where: { id },
-    include: { children: { orderBy: { sortOrder: 'asc' } } },
-  });
+  const [session, topic] = await Promise.all([
+    auth(),
+    prisma.knowledgePoint.findUnique({
+      where: { id },
+      include: { children: { orderBy: { sortOrder: 'asc' } } },
+    }),
+  ]);
   if (!topic) notFound();
 
+  const userId = session?.user?.id;
   const topicIds = await getDescendantTopicIds(id);
   const questions = await prisma.question.findMany({
     where: { knowledgePointId: { in: topicIds } },
@@ -26,6 +32,10 @@ export default async function TopicPracticePage({ params }: { params: Promise<{ 
       knowledgePoint: { select: { name: true, parent: { select: { name: true } } } },
     },
   });
+
+  const history: Map<string, QuestionHistoryEntry> = userId
+    ? await getQuestionHistory(userId, questions.map((q) => q.id))
+    : new Map();
 
   return (
     <main className="mx-auto mt-6 max-w-6xl space-y-6 md:mt-8">
@@ -50,21 +60,41 @@ export default async function TopicPracticePage({ params }: { params: Promise<{ 
         </div>
       </Card>
       <div className="grid gap-4">
-        {questions.map((question) => (
-          <Card key={question.id} className="p-5 hover:translate-y-0">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <p className="mb-2 text-sm font-black text-muted">
-                  2023 上午 · 第 {question.questionNumber} 题 ·{' '}
-                  {question.knowledgePoint.parent?.name ?? question.knowledgePoint.name} /{' '}
-                  {question.knowledgePoint.name}
-                </p>
-                <h2 className="text-lg font-black leading-relaxed text-navy">{question.content}</h2>
+        {questions.map((question) => {
+          const h = history.get(question.id);
+          return (
+            <Card key={question.id} className="p-5 hover:translate-y-0">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-black text-muted">
+                      2023 上午 · 第 {question.questionNumber} 题 ·{' '}
+                      {question.knowledgePoint.parent?.name ?? question.knowledgePoint.name} /{' '}
+                      {question.knowledgePoint.name}
+                    </p>
+                    {h ? (
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-bold ${
+                          h.lastIsCorrect
+                            ? 'bg-green-50 text-green-700'
+                            : 'bg-red-50 text-red-600'
+                        }`}
+                      >
+                        做过 {h.attempts} 次 · 上次 {h.lastIsCorrect ? '✓' : '✗'}
+                      </span>
+                    ) : (
+                      <span className="rounded-full bg-muted/10 px-2 py-0.5 text-xs font-bold text-muted">
+                        未做过
+                      </span>
+                    )}
+                  </div>
+                  <h2 className="text-lg font-black leading-relaxed text-navy">{question.content}</h2>
+                </div>
+                <FileQuestion className="h-7 w-7 shrink-0 text-primary" />
               </div>
-              <FileQuestion className="h-7 w-7 shrink-0 text-primary" />
-            </div>
-          </Card>
-        ))}
+            </Card>
+          );
+        })}
       </div>
     </main>
   );

--- a/src/app/api/practice/history/route.ts
+++ b/src/app/api/practice/history/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { getQuestionHistory } from '@/lib/question-history';
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ message: '未登录' }, { status: 401 });
+  const userId = session.user.id;
+
+  const { searchParams } = new URL(request.url);
+  const sessionId = searchParams.get('sessionId');
+  if (!sessionId) return NextResponse.json({ message: '缺少 sessionId' }, { status: 400 });
+
+  const practiceSession = await prisma.practiceSession.findFirst({
+    where: { id: sessionId, userId },
+    select: {
+      mode: true,
+      questions: { select: { questionId: true } },
+    },
+  });
+
+  if (!practiceSession) return NextResponse.json({ message: '会话不存在' }, { status: 404 });
+
+  const questionIds = practiceSession.questions.map((q) => q.questionId);
+  const historyMap = await getQuestionHistory(userId, questionIds, sessionId);
+
+  const history: Record<string, {
+    attempts: number;
+    correctCount: number;
+    lastIsCorrect: boolean;
+    lastSelectedOptionLabel: string;
+  }> = {};
+
+  for (const [questionId, entry] of historyMap) {
+    history[questionId] = {
+      attempts: entry.attempts,
+      correctCount: entry.correctCount,
+      lastIsCorrect: entry.lastIsCorrect,
+      lastSelectedOptionLabel: entry.lastSelectedOptionLabel,
+    };
+  }
+
+  return NextResponse.json({ mode: practiceSession.mode, history });
+}

--- a/src/app/api/practice/start/route.ts
+++ b/src/app/api/practice/start/route.ts
@@ -8,6 +8,7 @@ import { PRACTICE_AI_MAX_IDS, PRACTICE_DEFAULT_LIMIT, PRACTICE_MAX_LIMIT } from 
 import type { Prisma } from "@prisma/client";
 
 const ALLOWED_MODES = new Set(["random", "topic", "sequential", "ai"]);
+const ALLOWED_FILTERS = new Set(["all", "unanswered", "wrong-only"]);
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -17,6 +18,9 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const mode = String(body.mode ?? "random");
   if (!ALLOWED_MODES.has(mode)) return NextResponse.json({ message: "mode 参数不合法" }, { status: 400 });
+
+  const rawFilter = String(body.filter ?? "all");
+  const filter = ALLOWED_FILTERS.has(rawFilter) ? rawFilter : "all";
 
   const limit = clampInt(body.limit, 1, PRACTICE_MAX_LIMIT, PRACTICE_DEFAULT_LIMIT);
   const topicId = body.topicId ? String(body.topicId) : undefined;
@@ -40,6 +44,27 @@ export async function POST(request: Request) {
     orderBy = { questionNumber: "asc" };
   } else if (mode === "sequential") {
     orderBy = { questionNumber: "asc" };
+  }
+
+  if (mode !== "ai" && filter !== "all") {
+    if (filter === "unanswered") {
+      const answered = await prisma.userAnswer.findMany({
+        where: { userId },
+        select: { questionId: true },
+        distinct: ["questionId"],
+      });
+      const answeredIds = answered.map((a) => a.questionId);
+      where = { ...where, id: { notIn: answeredIds } };
+    } else if (filter === "wrong-only") {
+      const latestAnswers = await prisma.userAnswer.findMany({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        distinct: ["questionId"],
+        select: { questionId: true, isCorrect: true },
+      });
+      const wrongIds = latestAnswers.filter((a) => !a.isCorrect).map((a) => a.questionId);
+      where = { ...where, id: { in: wrongIds } };
+    }
   }
 
   let selected;

--- a/src/components/practice-filter-cards.tsx
+++ b/src/components/practice-filter-cards.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { Shuffle, ListOrdered } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { StartPracticeButton } from '@/components/start-practice-button';
+
+type Filter = 'all' | 'unanswered' | 'wrong-only';
+
+const FILTER_OPTIONS: { value: Filter; label: string }[] = [
+  { value: 'all', label: '全部' },
+  { value: 'unanswered', label: '没做过' },
+  { value: 'wrong-only', label: '做错过' },
+];
+
+function FilterToggle({ value, onChange }: { value: Filter; onChange: (v: Filter) => void }) {
+  return (
+    <div className="mt-4 flex gap-2">
+      {FILTER_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={`rounded-full px-3 py-1 text-xs font-black transition ${
+            value === opt.value
+              ? 'bg-primary text-white'
+              : 'bg-white/60 text-navy hover:bg-white'
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function PracticeFilterCards() {
+  const [randomFilter, setRandomFilter] = useState<Filter>('all');
+  const [seqFilter, setSeqFilter] = useState<Filter>('all');
+
+  return (
+    <>
+      <Card className="bg-softBlue p-6 sm:p-7">
+        <Shuffle className="h-10 w-10 text-primary" />
+        <h2 className="mt-5 text-2xl font-black text-navy">随机练习</h2>
+        <p className="mt-2 font-semibold text-muted">从题库随机抽取 20 题，适合快速热身。</p>
+        <FilterToggle value={randomFilter} onChange={setRandomFilter} />
+        <div className="mt-4">
+          <StartPracticeButton payload={{ mode: 'random', limit: 20, filter: randomFilter }}>
+            开始随机练习
+          </StartPracticeButton>
+        </div>
+      </Card>
+      <Card className="bg-softGreen p-6 sm:p-7">
+        <ListOrdered className="h-10 w-10 text-primary" />
+        <h2 className="mt-5 text-2xl font-black text-navy">顺序练习</h2>
+        <p className="mt-2 font-semibold text-muted">按年份和题号顺序推进，适合系统训练。</p>
+        <FilterToggle value={seqFilter} onChange={setSeqFilter} />
+        <div className="mt-4">
+          <StartPracticeButton payload={{ mode: 'sequential', limit: 20, filter: seqFilter }} variant="secondary">
+            开始顺序练习
+          </StartPracticeButton>
+        </div>
+      </Card>
+    </>
+  );
+}

--- a/src/components/practice-session.tsx
+++ b/src/components/practice-session.tsx
@@ -36,6 +36,38 @@ type Summary = {
   timeSpent: number;
   weakTopics: Array<{ name: string; wrong: number }>;
 };
+type QuestionHistoryEntry = {
+  attempts: number;
+  correctCount: number;
+  lastIsCorrect: boolean;
+  lastSelectedOptionLabel: string;
+};
+
+function QuestionHistoryChip({
+  entry,
+  showOption,
+}: {
+  entry: QuestionHistoryEntry | undefined;
+  showOption: boolean;
+}) {
+  if (!entry) {
+    return (
+      <span className="rounded-full bg-muted/10 px-2 py-0.5 text-xs font-bold text-muted">
+        未做过
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs font-bold ${
+        entry.lastIsCorrect ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-700'
+      }`}
+    >
+      做过 {entry.attempts} 次 · 上次{entry.lastIsCorrect ? '答对' : '答错'}
+      {showOption ? ` · 上次选了 ${entry.lastSelectedOptionLabel}` : ''}
+    </span>
+  );
+}
 
 function formatSeconds(seconds: number) {
   const minutes = Math.floor(seconds / 60)
@@ -59,6 +91,8 @@ export function PracticeSession() {
   const [elapsed, setElapsed] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [summary, setSummary] = useState<Summary | null>(null);
+  const [mode, setMode] = useState('');
+  const [history, setHistory] = useState<Record<string, QuestionHistoryEntry>>({});
 
   useEffect(() => {
     if (!sessionId) {
@@ -66,6 +100,21 @@ export function PracticeSession() {
       return;
     }
     let cancelled = false;
+
+    async function loadHistory() {
+      try {
+        const res = await fetch(`/api/practice/history?sessionId=${sessionId}`);
+        const data = await res.json().catch(() => ({}));
+        if (cancelled) return;
+        if (res.ok) {
+          setMode(data.mode ?? '');
+          setHistory(data.history ?? {});
+        }
+      } catch {
+        // history is non-critical; silently ignore
+      }
+    }
+
     const raw = sessionStorage.getItem(`ose-practice-${sessionId}`);
     if (raw) {
       try {
@@ -73,6 +122,7 @@ export function PracticeSession() {
         if (Array.isArray(parsed) && parsed.length) {
           setQuestions(parsed);
           setStartedAt(Date.now());
+          loadHistory();
           return;
         }
       } catch {
@@ -92,6 +142,7 @@ export function PracticeSession() {
         setQuestions(data.questions);
         setStartedAt(Date.now());
         if (data.results && typeof data.results === 'object') setResults(data.results);
+        loadHistory();
       } catch {
         if (!cancelled) router.replace('/practice');
       }
@@ -266,9 +317,12 @@ export function PracticeSession() {
       </Card>
 
       <Card className="p-5 sm:p-7 md:p-10">
-        <p className="mb-4 text-sm font-black text-muted">
-          2023 上午 · 第 {question.questionNumber} 题 · 难度 {question.difficulty}
-        </p>
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <p className="text-sm font-black text-muted">
+            2023 上午 · 第 {question.questionNumber} 题 · 难度 {question.difficulty}
+          </p>
+          {mode !== 'exam' && mode !== 'mock' && <QuestionHistoryChip entry={history[question.id]} showOption={Boolean(result)} />}
+        </div>
         <MarkdownRenderer
           content={question.content}
           className="text-xl font-black leading-relaxed text-navy md:text-3xl [&_img]:my-3 [&_img]:rounded-2xl"

--- a/src/components/start-practice-button.tsx
+++ b/src/components/start-practice-button.tsx
@@ -11,6 +11,7 @@ type StartPayload = {
   topicId?: string;
   limit?: number;
   questionIds?: string[];
+  filter?: 'all' | 'unanswered' | 'wrong-only';
 };
 
 export function StartPracticeButton({

--- a/src/lib/question-history.ts
+++ b/src/lib/question-history.ts
@@ -1,0 +1,71 @@
+import { prisma } from '@/lib/prisma';
+import type { Prisma } from '@prisma/client';
+
+export type QuestionHistoryEntry = {
+  attempts: number;
+  correctCount: number;
+  lastIsCorrect: boolean;
+  lastSelectedOptionLabel: string;
+  lastAt: Date;
+};
+
+export async function getQuestionHistory(
+  userId: string,
+  questionIds: string[],
+  excludeSessionId?: string,
+): Promise<Map<string, QuestionHistoryEntry>> {
+  if (questionIds.length === 0) return new Map();
+
+  const baseWhere: Prisma.UserAnswerWhereInput = {
+    userId,
+    questionId: { in: questionIds },
+  };
+
+  if (excludeSessionId) {
+    baseWhere.OR = [
+      { practiceSessionId: null },
+      { practiceSessionId: { not: excludeSessionId } },
+    ];
+  }
+
+  const [grouped, latestAnswers] = await Promise.all([
+    prisma.userAnswer.groupBy({
+      by: ['questionId', 'isCorrect'],
+      where: baseWhere,
+      _count: { id: true },
+    }),
+    prisma.userAnswer.findMany({
+      where: baseWhere,
+      orderBy: { createdAt: 'desc' },
+      distinct: ['questionId'],
+      select: {
+        questionId: true,
+        isCorrect: true,
+        createdAt: true,
+        selectedOption: { select: { label: true } },
+      },
+    }),
+  ]);
+
+  const attemptsMap = new Map<string, { attempts: number; correctCount: number }>();
+  for (const row of grouped) {
+    const current = attemptsMap.get(row.questionId) ?? { attempts: 0, correctCount: 0 };
+    current.attempts += row._count.id;
+    if (row.isCorrect) current.correctCount += row._count.id;
+    attemptsMap.set(row.questionId, current);
+  }
+
+  const result = new Map<string, QuestionHistoryEntry>();
+  for (const answer of latestAnswers) {
+    const stats = attemptsMap.get(answer.questionId) ?? { attempts: 0, correctCount: 0 };
+    result.set(answer.questionId, {
+      attempts: stats.attempts,
+      correctCount: stats.correctCount,
+      lastIsCorrect: answer.isCorrect,
+      lastSelectedOptionLabel: answer.selectedOption.label,
+      lastAt: answer.createdAt,
+    });
+  }
+
+  return result;
+}

--- a/src/test/question-history.test.ts
+++ b/src/test/question-history.test.ts
@@ -1,0 +1,263 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import { getQuestionHistory } from '@/lib/question-history';
+import {
+  createTestPracticeSession,
+  createTestUser,
+  resetUserData,
+  sessionFor,
+} from '@/test/helpers';
+
+async function getOptions() {
+  const correct = await prisma.questionOption.findFirstOrThrow({
+    where: { questionId: 'test-question-1', isCorrect: true },
+  });
+  const wrong = await prisma.questionOption.findFirstOrThrow({
+    where: { questionId: 'test-question-1', isCorrect: false },
+  });
+  return { correct, wrong };
+}
+
+async function loadStartRoute(session: unknown) {
+  vi.resetModules();
+  vi.doMock('@/lib/auth', () => ({ auth: async () => session }));
+  return import('@/app/api/practice/start/route');
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth');
+});
+
+describe('getQuestionHistory', () => {
+  beforeEach(resetUserData);
+
+  it('returns empty map when no answers exist', async () => {
+    const user = await createTestUser({ id: 'qh-u1', email: 'qh1@example.com' });
+    const result = await getQuestionHistory(user.id, ['test-question-1']);
+    expect(result.size).toBe(0);
+  });
+
+  it('aggregates attempts and correct count', async () => {
+    const user = await createTestUser({ id: 'qh-u2', email: 'qh2@example.com' });
+    const { correct, wrong } = await getOptions();
+    const sess = await createTestPracticeSession(user.id);
+
+    await prisma.userAnswer.createMany({
+      data: [
+        { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess.id, isCorrect: true, timeSpent: 10 },
+        { userId: user.id, questionId: 'test-question-1', selectedOptionId: wrong.id, practiceSessionId: sess.id, isCorrect: false, timeSpent: 10 },
+        { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess.id, isCorrect: true, timeSpent: 10 },
+      ],
+    });
+
+    const result = await getQuestionHistory(user.id, ['test-question-1']);
+    const entry = result.get('test-question-1');
+    expect(entry).toBeDefined();
+    expect(entry!.attempts).toBe(3);
+    expect(entry!.correctCount).toBe(2);
+  });
+
+  it('reflects the latest answer for lastIsCorrect', async () => {
+    const user = await createTestUser({ id: 'qh-u3', email: 'qh3@example.com' });
+    const { correct, wrong } = await getOptions();
+    const sess = await createTestPracticeSession(user.id);
+
+    // Insert older correct answer, then newer wrong answer
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess.id, isCorrect: true, timeSpent: 10, createdAt: new Date('2025-01-01') },
+    });
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: wrong.id, practiceSessionId: sess.id, isCorrect: false, timeSpent: 10, createdAt: new Date('2025-01-02') },
+    });
+
+    const result = await getQuestionHistory(user.id, ['test-question-1']);
+    const entry = result.get('test-question-1');
+    expect(entry!.lastIsCorrect).toBe(false);
+    expect(entry!.lastSelectedOptionLabel).toBe(wrong.label);
+  });
+
+  it('excludes the current session answers when excludeSessionId is provided', async () => {
+    const user = await createTestUser({ id: 'qh-u4', email: 'qh4@example.com' });
+    const { correct } = await getOptions();
+    const sess1 = await createTestPracticeSession(user.id);
+    const sess2 = await createTestPracticeSession(user.id);
+
+    // Answer in session 1 (old) and session 2 (current, should be excluded)
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess1.id, isCorrect: true, timeSpent: 10, createdAt: new Date('2025-01-01') },
+    });
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess2.id, isCorrect: true, timeSpent: 10, createdAt: new Date('2025-01-02') },
+    });
+
+    // Excluding sess2 → only sess1's answer counts
+    const result = await getQuestionHistory(user.id, ['test-question-1'], sess2.id);
+    const entry = result.get('test-question-1');
+    expect(entry!.attempts).toBe(1);
+  });
+
+  it('returns empty map for empty questionIds', async () => {
+    const user = await createTestUser({ id: 'qh-u5', email: 'qh5@example.com' });
+    const result = await getQuestionHistory(user.id, []);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('POST /api/practice/start – filter param', () => {
+  beforeEach(resetUserData);
+
+  it('filter=all (default) returns questions regardless of prior answers', async () => {
+    const user = await createTestUser({ id: 'qf-u1', email: 'qf1@example.com' });
+    const { correct } = await getOptions();
+    const sess = await createTestPracticeSession(user.id);
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess.id, isCorrect: true, timeSpent: 10 },
+    });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'all' }),
+        });
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.questions.length).toBeGreaterThan(0);
+      },
+    });
+  });
+
+  it('filter=unanswered excludes previously answered questions', async () => {
+    const user = await createTestUser({ id: 'qf-u2', email: 'qf2@example.com' });
+    const { correct } = await getOptions();
+    const sess = await createTestPracticeSession(user.id);
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess.id, isCorrect: true, timeSpent: 10 },
+    });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        // The only CHOICE question is test-question-1, which was answered → 404
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'unanswered' }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('filter=unanswered returns questions that have never been answered', async () => {
+    const user = await createTestUser({ id: 'qf-u3', email: 'qf3@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'unanswered' }),
+        });
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.questions.length).toBeGreaterThan(0);
+      },
+    });
+  });
+
+  it('filter=wrong-only returns questions whose LATEST answer is wrong', async () => {
+    const user = await createTestUser({ id: 'qf-u4', email: 'qf4@example.com' });
+    const { wrong } = await getOptions();
+    const sess = await createTestPracticeSession(user.id);
+    // Latest answer is wrong
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: wrong.id, practiceSessionId: sess.id, isCorrect: false, timeSpent: 10 },
+    });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'wrong-only' }),
+        });
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.questions.some((q: { id: string }) => q.id === 'test-question-1')).toBe(true);
+      },
+    });
+  });
+
+  it('filter=wrong-only excludes questions whose LATEST answer is correct (even with prior wrong answers)', async () => {
+    const user = await createTestUser({ id: 'qf-u5', email: 'qf5@example.com' });
+    const { correct, wrong } = await getOptions();
+    const sess = await createTestPracticeSession(user.id);
+
+    // First answer wrong, then correct → latest is correct → should NOT appear in wrong-only
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: wrong.id, practiceSessionId: sess.id, isCorrect: false, timeSpent: 10, createdAt: new Date('2025-01-01') },
+    });
+    await prisma.userAnswer.create({
+      data: { userId: user.id, questionId: 'test-question-1', selectedOptionId: correct.id, practiceSessionId: sess.id, isCorrect: true, timeSpent: 10, createdAt: new Date('2025-01-02') },
+    });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'wrong-only' }),
+        });
+        // Latest answer is correct → no wrong-only questions → 404
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('filter=wrong-only with no prior answers returns 404', async () => {
+    const user = await createTestUser({ id: 'qf-u6', email: 'qf6@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'wrong-only' }),
+        });
+        expect(response.status).toBe(404);
+      },
+    });
+  });
+
+  it('invalid filter value falls back to all', async () => {
+    const user = await createTestUser({ id: 'qf-u7', email: 'qf7@example.com' });
+    const appHandler = await loadStartRoute(sessionFor(user));
+
+    await testApiHandler({
+      appHandler,
+      async test({ fetch }) {
+        const response = await fetch({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'sequential', limit: 5, filter: 'invalid-filter' }),
+        });
+        expect(response.status).toBe(200);
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #44

## Changes

- Adds batched question history lookup with current-session exclusion support.
- Shows question-level history badges in topic practice lists.
- Shows non-spoiling answer history in the practice session header, hidden for exam/mock modes.
- Adds practice start filtering for `all`, `unanswered`, and `wrong-only`.
- Adds random/sequential practice filter toggles in the practice center.
- Adds focused tests for history aggregation and filter behavior.

## Verification

Claude could not run local npm commands due workflow tool permissions. CI should verify:
- `npm run typecheck`
- `npm test`