### PR TITLE
docs: use npm scripts for Prisma setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ git clone https://github.com/hacksynth/ose.git
 cd ose
 cp .env.example .env
 npm install
-npx prisma migrate dev
-npx prisma db seed
+npm run db:migrate
+npm run db:seed
 npm run dev
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -54,8 +54,8 @@ git clone https://github.com/hacksynth/ose.git
 cd ose
 cp .env.example .env
 npm install
-npx prisma migrate dev
-npx prisma db seed
+npm run db:migrate
+npm run db:seed
 npm run dev
 ```
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -13,8 +13,8 @@ DATABASE_URL="file:./dev.db"
 Initialize:
 
 ```bash
-npx prisma migrate dev
-npx prisma db seed
+npm run db:migrate
+npm run db:seed
 ```
 
 SQLite is simple and works well for local development, demos, and the desktop app.
@@ -39,9 +39,9 @@ PostgreSQL is recommended for multi-user deployments, backups, monitoring, and h
 
 ```bash
 npx prisma generate
-npx prisma migrate dev
+npm run db:migrate
 npx prisma migrate deploy
-npx prisma db seed
+npm run db:seed
 npx prisma studio
 ```
 


### PR DESCRIPTION
Replace bare Prisma migrate/seed commands in Quick Start and database docs with the project npm scripts that include the explicit schema path.

Closes #48