### PR TITLE
fix: remove obsolete Compose version field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   ose:
     image: ghcr.io/hacksynth/ose:latest


### PR DESCRIPTION
Remove the obsolete top-level ersion: '3.8' field from docker-compose.yml so Docker Compose v2 no longer warns while preserving service, environment, volume, and restart settings.

Closes #51