### PR TITLE
fix: classify reset-password as an auth route

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ const protectedRoutes = [
   '/knowledge',
   '/analysis',
 ];
-const authRoutes = ['/login', '/register'];
+const authRoutes = ['/login', '/register', '/reset-password'];
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/src/test/middleware.test.ts
+++ b/src/test/middleware.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { middleware } from '@/middleware';
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
+}));
+
+import { getToken } from 'next-auth/jwt';
+
+const mockGetToken = vi.mocked(getToken);
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(`http://localhost:3000${path}`);
+}
+
+beforeEach(() => {
+  mockGetToken.mockReset();
+});
+
+describe('middleware — protected routes', () => {
+  it('redirects unauthenticated user to /login with callbackUrl', async () => {
+    mockGetToken.mockResolvedValue(null);
+    const response = await middleware(makeRequest('/dashboard'));
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location')!);
+    expect(location.pathname).toBe('/login');
+    expect(location.searchParams.get('callbackUrl')).toBe('/dashboard');
+  });
+
+  it('allows authenticated user to access protected route', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never);
+    const response = await middleware(makeRequest('/dashboard'));
+    expect(response.status).toBe(200);
+  });
+});
+
+describe('middleware — auth routes (/login, /register, /reset-password)', () => {
+  it('redirects authenticated user away from /login to /dashboard', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never);
+    const response = await middleware(makeRequest('/login'));
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get('location')!).pathname).toBe('/dashboard');
+  });
+
+  it('allows unauthenticated user to visit /login', async () => {
+    mockGetToken.mockResolvedValue(null);
+    const response = await middleware(makeRequest('/login'));
+    expect(response.status).toBe(200);
+  });
+
+  it('redirects authenticated user away from /register to /dashboard', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never);
+    const response = await middleware(makeRequest('/register'));
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get('location')!).pathname).toBe('/dashboard');
+  });
+
+  it('allows unauthenticated user to visit /reset-password/verify', async () => {
+    mockGetToken.mockResolvedValue(null);
+    const response = await middleware(makeRequest('/reset-password/verify'));
+    expect(response.status).toBe(200);
+  });
+
+  it('redirects authenticated user away from /reset-password to /dashboard', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never);
+    const response = await middleware(makeRequest('/reset-password'));
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get('location')!).pathname).toBe('/dashboard');
+  });
+
+  it('redirects authenticated user away from /reset-password/verify to /dashboard', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never);
+    const response = await middleware(makeRequest('/reset-password/verify'));
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get('location')!).pathname).toBe('/dashboard');
+  });
+});


### PR DESCRIPTION
Add /reset-password to middleware auth routes so the matcher entry is no longer a no-op, and cover logged-in/logged-out behavior with middleware tests.

Closes #56