### PR TITLE
fix: generate desktop auth secret per install

### DIFF
--- a/.env.tauri
+++ b/.env.tauri
@@ -1,5 +1,6 @@
-# Tauri 桌面版配置
+# Tauri 桌面版配置 (非密钥默认值)
+# AUTH_SECRET 和 NEXTAUTH_SECRET 由 Tauri 在首次启动时自动生成，
+# 存储于 app data 目录的 auth.secret 文件，不在此处配置。
+# 如需在 tauri dev 模式下覆盖，请在 .env.local 中设置。
 NEXTAUTH_URL=http://localhost:19898
-NEXTAUTH_SECRET=ose-desktop-secret-change-me
 AUTH_URL=http://localhost:19898
-AUTH_SECRET=ose-desktop-secret-change-me

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -60,10 +60,43 @@ In production desktop mode, Tauri:
 
 1. Selects an available local port.
 2. Creates an app data directory.
-3. Sets `DATABASE_URL` to the local SQLite database.
-4. Starts `node start.js` — preferring the bundled `runtime/node[.exe]` when present, otherwise `node` from `PATH`.
-5. Polls `/api/ai/status` until the Next.js server is ready.
-6. Navigates the WebView to `http://127.0.0.1:<port>`.
+3. Resolves or generates the per-install auth secret (see [Auth Secret](#auth-secret) below).
+4. Sets `DATABASE_URL` to the local SQLite database.
+5. Starts `node start.js` — preferring the bundled `runtime/node[.exe]` when present, otherwise `node` from `PATH`.
+6. Polls `/api/ai/status` until the Next.js server is ready.
+7. Navigates the WebView to `http://127.0.0.1:<port>`.
+
+## Auth Secret
+
+Each desktop installation generates a unique auth secret the first time the app starts. This secret is used to sign Auth.js / NextAuth JWT session tokens. It is **not** shared across installations and **not** included in the app bundle or repository.
+
+### Storage location
+
+The secret is stored as a plain text file named `auth.secret` inside the app data directory:
+
+| Platform | Path |
+|----------|------|
+| Windows | `%AppData%\com.ose.softwareexam\auth.secret` |
+| macOS | `~/Library/Application Support/com.ose.softwareexam/auth.secret` |
+| Linux | `~/.local/share/com.ose.softwareexam/auth.secret` |
+
+On Unix-like platforms the file is created with `0600` (owner-read/write only) permissions. The file contains a 44-character Base64-encoded string derived from 32 cryptographically random bytes.
+
+### Secret reuse across restarts
+
+If `auth.secret` already exists when the app starts, the existing value is reused. Sessions remain valid across app restarts as long as the file is present.
+
+### Losing or deleting the secret
+
+If `auth.secret` is deleted or the app data directory is wiped:
+
+- A new secret is generated on the next launch.
+- All existing sessions signed with the old secret become invalid — users will be logged out.
+- No data is lost; only session validity is affected.
+
+### Development mode
+
+The `auth.secret` generation path only runs in release builds (`#[cfg(not(debug_assertions))]`). For `tauri dev`, set `AUTH_SECRET` and `NEXTAUTH_SECRET` in a `.env.local` file (already gitignored).
 
 ## Portable Zip (Windows)
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+base64 = "0.22"
+getrandom = "0.2"
 portpicker = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,6 +138,8 @@ fn start_next_server(app: &AppHandle) -> Result<u16, String> {
         &log_path,
     );
 
+    let auth_secret = resolve_or_create_auth_secret(&data_dir)?;
+
     let mut cmd = Command::new(&node_binary);
     cmd.arg(&start_script)
         .current_dir(&standalone_dir)
@@ -146,6 +148,8 @@ fn start_next_server(app: &AppHandle) -> Result<u16, String> {
         .env("DATABASE_URL", database_url)
         .env("AUTH_URL", format!("http://127.0.0.1:{port}"))
         .env("NEXTAUTH_URL", format!("http://127.0.0.1:{port}"))
+        .env("AUTH_SECRET", &auth_secret)
+        .env("NEXTAUTH_SECRET", &auth_secret)
         .env("NODE_ENV", "production")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -316,6 +320,65 @@ fn resolve_standalone_dir(app: &AppHandle) -> Result<PathBuf, String> {
         .collect::<Vec<_>>()
         .join("；");
     Err(format!("获取 standalone 目录失败，已检查：{checked}"))
+}
+
+fn resolve_or_create_auth_secret(data_dir: &PathBuf) -> Result<String, String> {
+    let secret_path = data_dir.join("auth.secret");
+
+    if secret_path.exists() {
+        let secret = fs::read_to_string(&secret_path)
+            .map_err(|e| format!("读取 auth.secret 失败：{e}"))?;
+        let secret = secret.trim().to_string();
+        if !secret.is_empty() {
+            return Ok(secret);
+        }
+    }
+
+    let mut raw = [0u8; 32];
+    getrandom::getrandom(&mut raw).map_err(|e| format!("生成随机密钥失败：{e}"))?;
+
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let secret = STANDARD.encode(raw);
+
+    write_secret_atomic(&secret_path, &secret)?;
+    Ok(secret)
+}
+
+// Creates the file with owner-only permissions from the start to avoid a
+// write-then-chmod race, then atomically renames it to the final path.
+fn write_secret_atomic(path: &PathBuf, secret: &str) -> Result<(), String> {
+    let tmp_path = path.with_extension("tmp");
+    let _ = fs::remove_file(&tmp_path);
+
+    {
+        let mut file = create_secret_file(&tmp_path)
+            .map_err(|e| format!("创建临时密钥文件失败：{e}"))?;
+        file.write_all(secret.as_bytes())
+            .map_err(|e| format!("写入临时密钥文件失败：{e}"))?;
+    }
+
+    fs::rename(&tmp_path, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp_path);
+        format!("写入 auth.secret 失败：{e}")
+    })
+}
+
+#[cfg(unix)]
+fn create_secret_file(path: &std::path::Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn create_secret_file(path: &std::path::Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
 }
 
 fn pick_port() -> Result<u16, String> {


### PR DESCRIPTION
Remove shared desktop Auth.js secrets from .env.tauri; generate and reuse a per-install base64 auth secret under the Tauri app data directory, inject it into the sidecar environment, and document storage and session behavior.

Closes #55