### PR TITLE
feat: unify AI default model resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,15 @@ CUSTOM_API_KEY=
 CUSTOM_BASE_URL=
 CUSTOM_MODEL=
 
+# --- AI Default Model Overrides / 默认模型覆盖 ---
+# Override built-in default models without code changes (for self-hosted operators)
+# 覆盖内置默认模型，无需修改代码（适用于自托管运营者）
+# Precedence / 优先级: explicit request > saved user setting > DEFAULT_*_MODEL env > built-in fallback
+DEFAULT_CLAUDE_MODEL=
+DEFAULT_OPENAI_MODEL=
+DEFAULT_GEMINI_MODEL=
+DEFAULT_CUSTOM_MODEL=
+
 # --- AI Image Provider / AI 生图供应商 ---
 # Options: openai | custom
 # 选项：openai | custom

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -125,3 +125,24 @@ server {
 ```
 
 Set `NEXTAUTH_URL=https://ose.example.com` when using HTTPS.
+
+## AI Model Defaults
+
+Built-in default models are updated periodically as providers release new generations, but self-hosted operators can override defaults without waiting for a release.
+
+Set any of these environment variables to pin a specific model for that provider:
+
+```env
+DEFAULT_CLAUDE_MODEL=claude-sonnet-4-6
+DEFAULT_OPENAI_MODEL=gpt-5-mini
+DEFAULT_GEMINI_MODEL=gemini-3-flash-preview
+DEFAULT_CUSTOM_MODEL=default
+```
+
+Model selection follows this precedence order:
+
+```
+explicit request/body model > saved user setting > DEFAULT_<PROVIDER>_MODEL env > built-in fallback
+```
+
+This means a user's saved model preference always wins, and the env override only applies when no model has been saved by the user.

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -3,28 +3,29 @@ import { createClaudeProvider } from "@/lib/ai/providers/claude";
 import { createOpenAIProvider } from "@/lib/ai/providers/openai";
 import { createGeminiProvider } from "@/lib/ai/providers/gemini";
 import { createCustomProvider } from "@/lib/ai/providers/custom";
+import { resolveDefaultModel } from "@/lib/ai/utils";
 import { prisma } from "@/lib/prisma";
 
 function envConfigFor(provider: AIProviderKey): AIConfig | null {
   if (provider === "claude") {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) return null;
-    return { provider, apiKey, model: process.env.ANTHROPIC_MODEL, baseUrl: process.env.ANTHROPIC_BASE_URL };
+    return { provider, apiKey, model: process.env.ANTHROPIC_MODEL || resolveDefaultModel("claude"), baseUrl: process.env.ANTHROPIC_BASE_URL };
   }
   if (provider === "openai") {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) return null;
-    return { provider, apiKey, model: process.env.OPENAI_MODEL, baseUrl: process.env.OPENAI_BASE_URL };
+    return { provider, apiKey, model: process.env.OPENAI_MODEL || resolveDefaultModel("openai"), baseUrl: process.env.OPENAI_BASE_URL };
   }
   if (provider === "gemini") {
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) return null;
-    return { provider, apiKey, model: process.env.GEMINI_MODEL, baseUrl: process.env.GEMINI_BASE_URL };
+    return { provider, apiKey, model: process.env.GEMINI_MODEL || resolveDefaultModel("gemini"), baseUrl: process.env.GEMINI_BASE_URL };
   }
   if (provider === "custom") {
     const baseUrl = process.env.CUSTOM_BASE_URL;
     if (!baseUrl) return null;
-    return { provider, apiKey: process.env.CUSTOM_API_KEY, model: process.env.CUSTOM_MODEL, baseUrl };
+    return { provider, apiKey: process.env.CUSTOM_API_KEY, model: process.env.CUSTOM_MODEL || resolveDefaultModel("custom"), baseUrl };
   }
   return null;
 }
@@ -59,7 +60,7 @@ export async function resolveAIConfig(userId?: string | null): Promise<AIConfig 
         return {
           provider,
           apiKey: settings?.apiKey ?? undefined,
-          model: settings?.model ?? undefined,
+          model: settings?.model || resolveDefaultModel(provider),
           baseUrl: settings?.baseUrl ?? undefined,
           visionSupport: settings?.visionSupport ?? null,
         };

--- a/src/lib/ai/providers/claude.ts
+++ b/src/lib/ai/providers/claude.ts
@@ -1,9 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
-import { getSanitizedEndpoint } from "@/lib/ai/utils";
+import { getSanitizedEndpoint, resolveDefaultModel } from "@/lib/ai/utils";
 
 const defaultBaseUrl = "https://api.anthropic.com";
-const defaultModel = "claude-sonnet-4-5-20250929";
 
 function parseDataUrl(url: string): { mediaType: "image/jpeg" | "image/png" | "image/gif" | "image/webp"; data: string } | null {
   const match = url.match(/^data:(image\/(?:jpeg|png|gif|webp));base64,(.+)$/);
@@ -37,7 +36,7 @@ function buildMessages(params: CompletionParams): Anthropic.MessageParam[] {
 
 export function createClaudeProvider(config: AIConfig): AIProvider {
   const apiKey = config.apiKey;
-  const model = config.model || defaultModel;
+  const model = config.model || resolveDefaultModel("claude");
   const baseUrl = config.baseUrl;
 
   function getClient() {

--- a/src/lib/ai/providers/custom.ts
+++ b/src/lib/ai/providers/custom.ts
@@ -1,9 +1,7 @@
 import OpenAI from "openai";
 import type { ChatCompletionContentPart, ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
-import { getSanitizedEndpoint, normalizeErrorMessage } from "@/lib/ai/utils";
-
-const defaultModel = "default";
+import { getSanitizedEndpoint, normalizeErrorMessage, resolveDefaultModel } from "@/lib/ai/utils";
 
 function buildMessages(params: CompletionParams): ChatCompletionMessageParam[] {
   if (params.messages?.length) {
@@ -36,7 +34,7 @@ function shouldRetryWithoutMaxTokens(error: unknown) {
 
 export function createCustomProvider(config: AIConfig): AIProvider {
   const baseUrl = config.baseUrl?.trim();
-  const model = config.model?.trim() || defaultModel;
+  const model = config.model?.trim() || resolveDefaultModel("custom");
   const configuredKey = config.apiKey?.trim();
 
   function getClient() {

--- a/src/lib/ai/providers/gemini.ts
+++ b/src/lib/ai/providers/gemini.ts
@@ -1,8 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
-import { fetchImageAsBase64, getSanitizedEndpoint } from "@/lib/ai/utils";
+import { fetchImageAsBase64, getSanitizedEndpoint, resolveDefaultModel } from "@/lib/ai/utils";
 
-const defaultModel = "gemini-2.5-flash";
 const defaultBaseUrl = "https://generativelanguage.googleapis.com";
 
 function parseDataUrl(url: string): { mimeType: string; base64: string } | null {
@@ -36,7 +35,7 @@ async function buildContents(params: CompletionParams) {
 
 export function createGeminiProvider(config: AIConfig): AIProvider {
   const apiKey = config.apiKey;
-  const model = config.model || defaultModel;
+  const model = config.model || resolveDefaultModel("gemini");
   const baseUrl = config.baseUrl?.trim();
 
   function getClient() {

--- a/src/lib/ai/providers/openai.ts
+++ b/src/lib/ai/providers/openai.ts
@@ -1,10 +1,9 @@
 import OpenAI from "openai";
 import type { ChatCompletionContentPart, ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import type { AIConfig, AIProvider, CompletionParams } from "@/lib/ai/types";
-import { getSanitizedEndpoint } from "@/lib/ai/utils";
+import { getSanitizedEndpoint, resolveDefaultModel } from "@/lib/ai/utils";
 
 const defaultBaseUrl = "https://api.openai.com/v1";
-const defaultModel = "gpt-4o-mini";
 
 function isVisionCapableModel(model: string): boolean {
   const m = model.toLowerCase();
@@ -45,7 +44,7 @@ function buildMessages(params: CompletionParams): ChatCompletionMessageParam[] {
 
 export function createOpenAIProvider(config: AIConfig): AIProvider {
   const apiKey = config.apiKey;
-  const model = config.model || defaultModel;
+  const model = config.model || resolveDefaultModel("openai");
   const baseUrl = config.baseUrl;
 
   function getClient() {

--- a/src/lib/ai/settings.ts
+++ b/src/lib/ai/settings.ts
@@ -4,15 +4,8 @@ import OpenAI from "openai";
 
 import { buildAIProvider, resolveAIConfig } from "@/lib/ai";
 import type { AIConfig, AIProviderKey } from "@/lib/ai/types";
-import { normalizeErrorMessage } from "@/lib/ai/utils";
+import { normalizeErrorMessage, resolveDefaultModel } from "@/lib/ai/utils";
 import { prisma } from "@/lib/prisma";
-
-const DEFAULT_MODELS: Record<AIProviderKey, string> = {
-  claude: "claude-sonnet-4-5-20250929",
-  openai: "gpt-4o-mini",
-  gemini: "gemini-2.5-flash",
-  custom: "default",
-};
 
 const DEFAULT_BASE_URLS: Record<AIProviderKey, string | undefined> = {
   claude: "https://api.anthropic.com",
@@ -80,7 +73,7 @@ export async function testAIConfig(config: AIConfig) {
   const startedAt = Date.now();
   const provider = buildAIProvider({
     ...config,
-    model: config.model || DEFAULT_MODELS[config.provider],
+    model: config.model || resolveDefaultModel(config.provider),
   });
   const content = await provider.createCompletion({
     systemPrompt: "You are a connectivity checker. Reply with exactly: OK",
@@ -106,7 +99,7 @@ export async function testVisionCapability(config: AIConfig): Promise<{ supports
   const startedAt = Date.now();
   const provider = buildAIProvider({
     ...config,
-    model: config.model || DEFAULT_MODELS[config.provider],
+    model: config.model || resolveDefaultModel(config.provider),
     visionSupport: null,
   });
   try {

--- a/src/lib/ai/utils.ts
+++ b/src/lib/ai/utils.ts
@@ -1,5 +1,20 @@
 import { NextResponse } from "next/server";
 
+const BUILT_IN_DEFAULT_MODELS: Record<string, string> = {
+  claude: "claude-sonnet-4-6",
+  openai: "gpt-5-mini",
+  gemini: "gemini-3-flash-preview",
+  custom: "default",
+};
+
+export function resolveDefaultModel(provider: string): string {
+  return (
+    process.env[`DEFAULT_${provider.toUpperCase()}_MODEL`] ||
+    BUILT_IN_DEFAULT_MODELS[provider] ||
+    "default"
+  );
+}
+
 type AIErrorDetails = {
   message: string;
   status: number;

--- a/src/test/ai-settings-defaults.test.ts
+++ b/src/test/ai-settings-defaults.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveDefaultModel } from '@/lib/ai/utils';
+
+const DEFAULT_MODEL_ENV_KEYS = [
+  'DEFAULT_CLAUDE_MODEL',
+  'DEFAULT_OPENAI_MODEL',
+  'DEFAULT_GEMINI_MODEL',
+  'DEFAULT_CUSTOM_MODEL',
+] as const;
+
+function clearDefaultModelEnv() {
+  for (const key of DEFAULT_MODEL_ENV_KEYS) delete process.env[key];
+}
+
+describe('resolveDefaultModel', () => {
+  beforeEach(() => clearDefaultModelEnv());
+  afterEach(() => clearDefaultModelEnv());
+
+  it('returns built-in default for claude when no env override', () => {
+    expect(resolveDefaultModel('claude')).toBe('claude-sonnet-4-6');
+  });
+
+  it('returns built-in default for openai when no env override', () => {
+    expect(resolveDefaultModel('openai')).toBe('gpt-5-mini');
+  });
+
+  it('returns built-in default for gemini when no env override', () => {
+    expect(resolveDefaultModel('gemini')).toBe('gemini-3-flash-preview');
+  });
+
+  it('returns built-in default for custom when no env override', () => {
+    expect(resolveDefaultModel('custom')).toBe('default');
+  });
+
+  it('reads DEFAULT_CLAUDE_MODEL env override', () => {
+    process.env.DEFAULT_CLAUDE_MODEL = 'claude-opus-4-7';
+    expect(resolveDefaultModel('claude')).toBe('claude-opus-4-7');
+  });
+
+  it('reads DEFAULT_OPENAI_MODEL env override', () => {
+    process.env.DEFAULT_OPENAI_MODEL = 'gpt-5';
+    expect(resolveDefaultModel('openai')).toBe('gpt-5');
+  });
+
+  it('reads DEFAULT_GEMINI_MODEL env override', () => {
+    process.env.DEFAULT_GEMINI_MODEL = 'gemini-3-pro';
+    expect(resolveDefaultModel('gemini')).toBe('gemini-3-pro');
+  });
+
+  it('reads DEFAULT_CUSTOM_MODEL env override', () => {
+    process.env.DEFAULT_CUSTOM_MODEL = 'my-local-llm';
+    expect(resolveDefaultModel('custom')).toBe('my-local-llm');
+  });
+
+  it('falls back to built-in when env override is empty string', () => {
+    process.env.DEFAULT_CLAUDE_MODEL = '';
+    expect(resolveDefaultModel('claude')).toBe('claude-sonnet-4-6');
+  });
+
+  it('overrides are independent per provider', () => {
+    process.env.DEFAULT_OPENAI_MODEL = 'gpt-5';
+    expect(resolveDefaultModel('claude')).toBe('claude-sonnet-4-6');
+    expect(resolveDefaultModel('openai')).toBe('gpt-5');
+    expect(resolveDefaultModel('gemini')).toBe('gemini-3-flash-preview');
+  });
+});


### PR DESCRIPTION
Refresh built-in AI default models and add DEFAULT_<PROVIDER>_MODEL overrides across env config, saved user settings, provider fallback, and connection-test paths, with docs and tests for precedence.

Closes #58