### PR TITLE
ci: install fuse for linux release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
             curl \
             wget \
             file \
+            libfuse2 \
             patchelf \
             libssl-dev \
             rpm \


### PR DESCRIPTION
## Summary
- install libfuse2 in the Linux release job so linuxdeploy AppImage can run during AppImage packaging

## Context
- v0.1.2 release run failed in the Linux x64 job at the linuxdeploy AppImage bundling step

## Validation
- workflow-only change