### PR TITLE
ci: run appimage tools without fuse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ env:
   AUTH_SECRET: release-secret
   NEXT_PUBLIC_EXAM_DATE: 2026-05-23
   OSE_MOBILE_URL: ${{ vars.OSE_MOBILE_URL || secrets.OSE_MOBILE_URL }}
+  APPIMAGE_EXTRACT_AND_RUN: 1
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- set APPIMAGE_EXTRACT_AND_RUN=1 in the release workflow so linuxdeploy AppImage tools can run in GitHub-hosted Linux runners without relying on FUSE mounts

## Context
- v0.1.2 release still failed in Linux x64 at the linuxdeploy AppImage bundling step after installing libfuse2

## Validation
- workflow-only change